### PR TITLE
feat: add expedition ended screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "4.0.3",
+    "recoil": "0.4.1",
     "web-vitals": "1.0.1"
   },
   "devDependencies": {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,6 +1,7 @@
 import './app.css'
 import { loadFonts } from 'fonts'
 import { useCallback, useState } from 'react'
+import { RecoilRoot } from 'recoil'
 
 import { DungeonScreen } from './dungeon-screen'
 import { ExpeditionEndedScreen } from './expedition-ended-screen'
@@ -31,7 +32,13 @@ function App () {
     }
   }
 
-  return ready ? getActiveScreen() : <div>Loading...</div>
+  return (
+    <RecoilRoot>{
+      ready
+        ? getActiveScreen()
+        : <div>Loading...</div>
+    }</RecoilRoot>
+  )
 }
 
 export default App

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -3,13 +3,14 @@ import { loadFonts } from 'fonts'
 import { useCallback, useState } from 'react'
 
 import { DungeonScreen } from './dungeon-screen'
+import { ExpeditionEndedScreen } from './expedition-ended-screen'
 import { TitleScreen } from './title-screen'
 
-export type ScreenName = 'dungeon' | 'exit' | 'game-over' | 'title'
+export type ScreenName = 'dungeon' | 'expedition-ended' | 'title'
 
 function App () {
   const [ready, setReady] = useState(false)
-  const [activeScreen, setActiveScreen] = useState<ScreenName>('title')
+  const [activeScreen, setActiveScreen] = useState<ScreenName>('expedition-ended')
 
   loadFonts().then(() => setReady(true))
 
@@ -21,6 +22,9 @@ function App () {
     switch (activeScreen) {
       case 'dungeon':
         return <DungeonScreen />
+
+      case 'expedition-ended':
+        return <ExpeditionEndedScreen navigateTo={setActiveScreen} />
 
       default:
         return <TitleScreen exit={handleExit} navigateTo={setActiveScreen} />

--- a/src/components/expedition-ended-screen.css
+++ b/src/components/expedition-ended-screen.css
@@ -1,0 +1,24 @@
+.screen-container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.screen-content-container {
+  margin-top: 64px;
+}
+
+.screen-footer {
+  font-size: 2em;
+  margin-bottom: 32px;
+  margin-top: auto;
+}
+
+.screen-title {
+  font-family: VT323;
+  font-size: 5em;
+  letter-spacing: 0.05em;
+  margin: 64px 0 32px 0;
+  text-align: center;
+}

--- a/src/components/expedition-ended-screen.css
+++ b/src/components/expedition-ended-screen.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   height: 100vh;
 }
+.screen-container:focus { outline: none; }
 
 .screen-content-container {
   margin-top: 64px;
@@ -21,4 +22,9 @@
   letter-spacing: 0.05em;
   margin: 64px 0 32px 0;
   text-align: center;
+}
+
+.expedition-ended-character-name {
+  margin-top: 0;
+  padding: 0;
 }

--- a/src/components/expedition-ended-screen.tsx
+++ b/src/components/expedition-ended-screen.tsx
@@ -1,3 +1,8 @@
+import { PropsWithChildren, useCallback } from 'react'
+import { useRecoilValue } from 'recoil'
+import { expeditionState } from 'state/expedition'
+import { playerState } from 'state/player'
+
 import { ScreenName } from './app'
 import './expedition-ended-screen.css'
 import { Panel } from './panel'
@@ -7,17 +12,52 @@ export interface ExpeditionEndedScreenProps {
   navigateTo: (screen: ScreenName) => void
 }
 
-export const ExpeditionEndedScreen = (_: ExpeditionEndedScreenProps) => {
+const MultiLineText = ({ children }: PropsWithChildren<Record<string, unknown>>) => (
+  <div style={{ whiteSpace: 'pre-line' }}>{children}</div>
+)
+
+export const ExpeditionEndedScreen = ({ navigateTo }: ExpeditionEndedScreenProps) => {
+  const expedition = useRecoilValue(expeditionState)
+  const player = useRecoilValue(playerState)
+
+  // update the focus when a new UL element is created
+  const refCallback = useCallback((ul: HTMLDivElement) => {
+    ul?.focus()
+  }, [])
+
+  // handle blur events by taking focus back
+  // works on this screen, because we only have one element that we want to handle input
+  const handleBlur = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    event.target.focus()
+  }, [])
+
+  const returnToTitle = useCallback(() => {
+    navigateTo('title')
+  }, [navigateTo])
+
+  const expeditionSummary =
+    `${player.name}
+    
+    Turn: ${expedition.turn}`
+
   return (
-    <div className="screen-container">
+    <div
+      className="screen-container"
+      onBlur={handleBlur}
+      onClick={returnToTitle}
+      onKeyPress={returnToTitle}
+      ref={refCallback}
+      tabIndex={0}
+    >
       <h1 className="screen-title">Your Expedition has Ended</h1>
-      <Panel
-        containerClass="screen-content-container"
-        rows={25}
-        columns={90}
-      >
-        Lipsum
-      </Panel>
+      <div className="screen-content-container">
+        <Panel
+          rows={25}
+          columns={90}
+        >
+          <MultiLineText>{expeditionSummary}</MultiLineText>
+        </Panel>
+      </div>
       <p className="screen-footer animated-option">Press any key to continue </p>
     </div>
   )

--- a/src/components/expedition-ended-screen.tsx
+++ b/src/components/expedition-ended-screen.tsx
@@ -1,0 +1,24 @@
+import { ScreenName } from './app'
+import './expedition-ended-screen.css'
+import { Panel } from './panel'
+
+export interface ExpeditionEndedScreenProps {
+  /** function that allows inter-screen navigation */
+  navigateTo: (screen: ScreenName) => void
+}
+
+export const ExpeditionEndedScreen = (_: ExpeditionEndedScreenProps) => {
+  return (
+    <div className="screen-container">
+      <h1 className="screen-title">Your Expedition has Ended</h1>
+      <Panel
+        containerClass="screen-content-container"
+        rows={25}
+        columns={90}
+      >
+        Lipsum
+      </Panel>
+      <p className="screen-footer animated-option">Press any key to continue </p>
+    </div>
+  )
+}

--- a/src/components/panel.css
+++ b/src/components/panel.css
@@ -1,5 +1,4 @@
 .container {
-  align-self: flex-start;
   border: 1px solid #333;
   display: flex;
   align-content: stretch;

--- a/src/components/title-screen.css
+++ b/src/components/title-screen.css
@@ -1,4 +1,4 @@
-h1 {
+.game-title {
   font-family: VT323;
   font-size: 20em;
   letter-spacing: 0.05em;
@@ -6,7 +6,7 @@ h1 {
   text-align: center;
 }
 
-ul {
+.screen-menu {
   border-top: 2px solid gray;
   margin-left: auto;
   margin-right: auto;
@@ -14,9 +14,9 @@ ul {
   text-align: center;
   width: 450px;
 }
-ul:focus { outline: none; }
+.screen-menu:focus { outline: none; }
 
-li {
+.screen-menu li {
   font-size: 72px;
   list-style-type: none;
   margin: 0 0 48px 0;
@@ -34,21 +34,8 @@ li {
   }
 }
 
-li.selected:after { 
-  content: ' <'; 
-}
-li.selected:before { 
-  content: '> '; 
-}
-li.selected {
-  animation-direction: alternate;
-  animation-duration: 650ms;
-  animation-timing-function: linear;
-  animation-name: breathing;
-  animation-iteration-count: infinite;
-  color: red;
-}
 
-li:last-child {
+
+.screen-menu li:last-child {
   margin-bottom: 0;
 }

--- a/src/components/title-screen.css
+++ b/src/components/title-screen.css
@@ -34,8 +34,6 @@
   }
 }
 
-
-
 .screen-menu li:last-child {
   margin-bottom: 0;
 }

--- a/src/components/title-screen.tsx
+++ b/src/components/title-screen.tsx
@@ -91,6 +91,7 @@ const Menu = ({
 
   return (
     <ul
+      className="screen-menu"
       onBlur={handleBlur}
       onKeyDown={handleKeyPress}
       ref={refCallback}
@@ -99,7 +100,7 @@ const Menu = ({
       {map((name: string) => (
         <li
           key={name}
-          className={selectedItem === name ? 'selected' : ''}
+          className={selectedItem === name ? 'animated-option' : ''}
           onMouseEnter={handleHover(name)}
           onClick={handleClick(name)}
         >
@@ -113,7 +114,7 @@ const Menu = ({
 export const TitleScreen = ({ exit, navigateTo }: TitleScreenProps) => {
   return (
     <>
-      <h1>Shift</h1>
+      <h1 className="game-title">Shift</h1>
       <Menu
         items={['New Game', 'Exit']}
         onSelectionConfirmed={(item) => {

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,17 @@ body {
   color: white;
 }
 
+.animated-option:after { 
+  content: ' <'; 
+}
+.animated-option:before { 
+  content: '> '; 
+}
+.animated-option {
+  animation-direction: alternate;
+  animation-duration: 650ms;
+  animation-timing-function: linear;
+  animation-name: breathing;
+  animation-iteration-count: infinite;
+  color: red;
+}

--- a/src/state/expedition.ts
+++ b/src/state/expedition.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil'
+
+export interface Expedition {
+  /** the current turn number */
+  turn: number
+}
+
+export const expeditionState = atom<Expedition>({
+  key: 'expeditionState',
+  default: {
+    turn: 1,
+  },
+})

--- a/src/state/player.ts
+++ b/src/state/player.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil'
+
+export interface Player {
+  /** player's character name */
+  name: string
+}
+
+export const playerState = atom<Player>({
+  key: 'playerState',
+  default: {
+    name: 'Mystericus the Untitled',
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6668,6 +6668,11 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -11124,6 +11129,13 @@ readdirp@~3.5.0:
   integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.4.1.tgz#1cb2171bc98d41361507131a059d7c3525d8c4fe"
+  integrity sha512-vp6KPwlHOjJ4bJofmdDchmgI9ilMTCoUisK8/WYLl8dThH7e7KmtZttiLgvDb2Em99dUfTEsk8vT8L1nUMgqXQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 recursive-readdir@2.2.2:
   version "2.2.2"


### PR DESCRIPTION
- Refactored title screen styles to avoid collisions and increase reuse.
- Add initial 'expedition ended' screen layout.
- Add ultra-minimal state definitions for the player and current expedition.
- Update expedition end screen to show some 'stats'.
