### PR TITLE
feat: transition to expedition ended when link is depleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@pixi/unsafe-eval": "6.2.0",
-    "@react-hook/size": "2.1.2",
     "@testing-library/jest-dom": "5.11.4",
     "@testing-library/react": "11.1.0",
     "@testing-library/user-event": "12.1.10",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -11,7 +11,7 @@ export type ScreenName = 'dungeon' | 'expedition-ended' | 'title'
 
 function App () {
   const [ready, setReady] = useState(false)
-  const [activeScreen, setActiveScreen] = useState<ScreenName>('expedition-ended')
+  const [activeScreen, setActiveScreen] = useState<ScreenName>('title')
 
   loadFonts().then(() => setReady(true))
 
@@ -22,7 +22,7 @@ function App () {
   const getActiveScreen = () => {
     switch (activeScreen) {
       case 'dungeon':
-        return <DungeonScreen />
+        return <DungeonScreen navigateTo={setActiveScreen}/>
 
       case 'expedition-ended':
         return <ExpeditionEndedScreen navigateTo={setActiveScreen} />

--- a/src/components/dungeon-screen.tsx
+++ b/src/components/dungeon-screen.tsx
@@ -1,16 +1,41 @@
 /* eslint-disable max-len */
+import { useEffect } from 'react'
+import { useExpedition } from 'state/expedition'
+
+import { ScreenName } from './app'
 import './dungeon-screen.css'
 import { MapPanel } from './map-panel-pixi'
 import { Panel } from './panel'
 
 const SidebarColumns = 30
 
-export const DungeonScreen = () => {
+export interface ExpeditionScreenProps {
+  /** function that allows inter-screen navigation */
+  navigateTo: (screen: ScreenName) => void
+}
+
+export const DungeonScreen = ({ navigateTo }: ExpeditionScreenProps) => {
+  const expedition = useExpedition()
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      expedition.nextTurn()
+    }, 100)
+
+    if (expedition.link < 1) {
+      navigateTo('expedition-ended')
+    }
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [expedition, navigateTo])
+
   return (
     <div className="dungeon-screen">
       <div className="sidebar">
         <Panel columns={SidebarColumns} rows={3}>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam porta ac diam at facilisis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Praesent bibendum auctor congue. Morbi a dapibus tortor. Quisque in faucibus justo, sit amet vehicula lectus. Maecenas pellentesque tincidunt lectus, in convallis ipsum ullamcorper nec. Nulla fermentum aliquam eros, ut molestie massa venenatis at. Nulla faucibus tempus metus, et faucibus ipsum volutpat eget. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Morbi et nulla non enim euismod gravida sit amet ut dui. Nulla et eros eget nisi consequat tincidunt. Praesent mollis dui congue dignissim venenatis. Curabitur est nulla, eleifend ut orci eget, porttitor lobortis lorem. Vivamus turpis magna, pulvinar sed dolor vel, congue aliquet turpis. Pellentesque dictum sollicitudin gravida. Ut a est sed tortor pretium tempus. Morbi eget scelerisque orci. In rutrum odio est, eu faucibus massa viverra ut. Fusce convallis iaculis cursus. Proin sed neque a dui vehicula faucibus. Praesent sit amet bibendum sapien, ultrices sagittis sapien. Etiam facilisis dapibus orci eget aliquet. Nam congue porttitor varius. Integer maximus arcu id ullamcorper placerat. Donec quis egestas mi, at ultricies dolor. Mauris rutrum urna sed eros consequat semper. Aliquam tincidunt in elit at feugiat. Morbi et lorem congue, facilisis mi ac, fringilla enim. Cras aliquam lacus ut augue porttitor pulvinar. Fusce in lectus turpis. Donec consectetur enim quis blandit sagittis. Mauris interdum lectus nisi, vel rhoncus turpis laoreet sed. Sed egestas finibus tempor. Nullam rutrum dapibus turpis, ut vehicula justo vehicula in. Praesent eu augue fermentum, malesuada ex et, vestibulum nulla. Duis condimentum rutrum velit non aliquam. Donec maximus nisi metus, et vehicula nisi aliquet non. Curabitur arcu neque, tempor nec ipsum id, imperdiet sollicitudin neque. Praesent bibendum tristique dapibus. Morbi aliquet fringilla mauris, sed sodales risus porttitor nec. Quisque bibendum tincidunt dolor, vitae faucibus neque scelerisque id. Proin ut consequat ligula. Quisque rhoncus augue at libero ultrices, non imperdiet lorem laoreet. Donec tempor tempor sem condimentum ornare. Curabitur elementum sollicitudin convallis. Integer et laoreet arcu, laoreet laoreet turpis. Aenean sit amet nibh ut nisi suscipit laoreet vitae et odio. Duis aliquet commodo ligula porttitor fermentum. Maecenas convallis molestie nulla, nec rhoncus tortor suscipit sed. Pellentesque eu erat ut nisl pretium interdum. Nulla sagittis, neque at faucibus luctus, tortor ligula laoreet mi, at efficitur justo mauris eu sem. Praesent blandit volutpat quam, facilisis bibendum enim pharetra a. Vestibulum eu euismod urna.
+          Link: {expedition.link}
         </Panel>
 
         <Panel columns={SidebarColumns}>

--- a/src/components/expedition-ended-screen.css
+++ b/src/components/expedition-ended-screen.css
@@ -23,7 +23,6 @@
   margin: 64px 0 32px 0;
   text-align: center;
 }
-
 .expedition-ended-character-name {
   margin-top: 0;
   padding: 0;

--- a/src/components/expedition-ended-screen.tsx
+++ b/src/components/expedition-ended-screen.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useCallback } from 'react'
 import { useRecoilValue } from 'recoil'
-import { expeditionState } from 'state/expedition'
+import { useExpedition } from 'state/expedition'
 import { playerState } from 'state/player'
 
 import { ScreenName } from './app'
@@ -17,7 +17,7 @@ const MultiLineText = ({ children }: PropsWithChildren<Record<string, unknown>>)
 )
 
 export const ExpeditionEndedScreen = ({ navigateTo }: ExpeditionEndedScreenProps) => {
-  const expedition = useRecoilValue(expeditionState)
+  const expedition = useExpedition()
   const player = useRecoilValue(playerState)
 
   // update the focus when a new UL element is created
@@ -32,13 +32,14 @@ export const ExpeditionEndedScreen = ({ navigateTo }: ExpeditionEndedScreenProps
   }, [])
 
   const returnToTitle = useCallback(() => {
+    expedition.reset()
     navigateTo('title')
-  }, [navigateTo])
+  }, [expedition, navigateTo])
 
   const expeditionSummary =
     `${player.name}
     
-    Turn: ${expedition.turn}`
+    Turns: ${expedition.turn - 1}`
 
   return (
     <div

--- a/src/components/map-panel-pixi.tsx
+++ b/src/components/map-panel-pixi.tsx
@@ -1,6 +1,5 @@
 import { ShaderSystem } from '@pixi/core'
 import { install } from '@pixi/unsafe-eval'
-import useSize from '@react-hook/size'
 import { FontNames } from 'fonts'
 import { times } from 'lodash'
 import { map, slice } from 'lodash/fp'
@@ -34,23 +33,21 @@ const lines = generateLines()
 export const MapPanel = () => {
   const canvasRef = useRef<HTMLDivElement>(null)
   const appRef = useRef<PIXI.Application | null>(null)
-  const [width, height] = useSize(canvasRef)
 
   const [x, setX] = useState(0)
   const [y, setY] = useState(0)
 
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log('resize!', width, height)
-  }, [width, height])
-
-  useEffect(() => {
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       setX((x + 1) % 4500)
       if (x % 2 === 0) {
         setY((y + 1) % 4500)
       }
     }, 1000 / 20)
+
+    return () => {
+      clearTimeout(timeout)
+    }
   })
 
   const rowSelection = slice(y, y + 250, lines)

--- a/src/state/expedition.ts
+++ b/src/state/expedition.ts
@@ -1,13 +1,48 @@
-import { atom } from 'recoil'
+import { atom, useRecoilState } from 'recoil'
+
+const InitialLinkValue = 50
 
 export interface Expedition {
+  /** the strength of the player's link to the current expedition's location */
+  link: number
+
   /** the current turn number */
   turn: number
+}
+
+export interface ExpeditionModel extends Expedition {
+  /** finish the expedition turn, and move the simulation to the next one */
+  nextTurn: () => void
+
+  /** reset the expedition to prepare a new one to start */
+  reset: () => void
 }
 
 export const expeditionState = atom<Expedition>({
   key: 'expeditionState',
   default: {
+    link: InitialLinkValue,
     turn: 1,
   },
 })
+
+export const useExpedition = (): ExpeditionModel => {
+  const [expedition, setExpedition] = useRecoilState(expeditionState)
+
+  return {
+    ...expedition,
+    nextTurn: () => {
+      setExpedition((old) => ({
+        ...old,
+        link: old.link - 1,
+        turn: old.turn + 1,
+      }))
+    },
+    reset: () => {
+      setExpedition({
+        link: InitialLinkValue,
+        turn: 1,
+      })
+    },
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,11 +1475,6 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@juggle/resize-observer@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
-  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
-
 "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz#504af200af6b98e198bce768bc1730c6936ae01d"
@@ -1727,35 +1722,6 @@
     native-url "^0.2.6"
     schema-utils "^2.6.5"
     source-map "^0.7.3"
-
-"@react-hook/latest@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"
-  integrity sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==
-
-"@react-hook/passive-layout-effect@^1.2.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
-  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
-
-"@react-hook/resize-observer@^1.2.1":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@react-hook/resize-observer/-/resize-observer-1.2.4.tgz#5fb2abe3566c693629f9ad690b979d61004d0df8"
-  integrity sha512-ouYbtX9kcwG6a52cl2JiIm2e846bQ00RZ/3ATs7yDke/4Z/SG/+SWU8WTdCcBBS4R25nhBsbAjWdd85kHuhO6g==
-  dependencies:
-    "@juggle/resize-observer" "^3.3.1"
-    "@react-hook/latest" "^1.0.2"
-    "@react-hook/passive-layout-effect" "^1.2.0"
-    "@types/raf-schd" "^4.0.0"
-    raf-schd "^4.0.2"
-
-"@react-hook/size@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@react-hook/size/-/size-2.1.2.tgz#87ed634ffb200f65d3e823501e5559aa3d584451"
-  integrity sha512-BmE5asyRDxSuQ9p14FUKJ0iBRgV9cROjqNG9jT/EjCM+xHha1HVqbPoT+14FQg1K7xIydabClCibUY4+1tw/iw==
-  dependencies:
-    "@react-hook/passive-layout-effect" "^1.2.0"
-    "@react-hook/resize-observer" "^1.2.1"
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
@@ -2205,11 +2171,6 @@
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
-
-"@types/raf-schd@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/raf-schd/-/raf-schd-4.0.1.tgz#1f9e03736f277fe9c7b82102bf18570a6ee19f82"
-  integrity sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A==
 
 "@types/react@17.0.33":
   version "17.0.33"
@@ -10838,11 +10799,6 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
-
-raf-schd@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
-  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
 
 raf@^3.4.1:
   version "3.4.1"


### PR DESCRIPTION
- Add initial 'expedition ended' screen layout.
- Remove unused map panel code and cleanup timers.
- Decrement link value as turns progress, and transition to 'game over' when it's depleted.
