### PR TITLE
feat: add pause menu and quit function

### DIFF
--- a/src/components/expedition-screen.tsx
+++ b/src/components/expedition-screen.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable max-len */
-import { useEffect } from 'react'
+import { useKeyHandler } from 'hooks/use-key-handler'
+import { useCallback, useEffect } from 'react'
 import { useRecoilValue } from 'recoil'
-import { endTurn as endExpeditionTurn, expeditionState } from 'state/expedition'
+import { gameState, pause } from 'state/game'
 import { useModel } from 'state/hooks'
-import { dealDamage, endTurn, isExpeditionComplete, playerState } from 'state/player'
+import { isExpeditionComplete, playerState } from 'state/player'
 
 import { ScreenName } from './app'
 import { MapPanel } from './map-panel-pixi'
@@ -21,30 +22,26 @@ export interface ExpeditionScreenProps {
 
 export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
   const isComplete = useRecoilValue(isExpeditionComplete)
+  const game = useModel(gameState)
   const player = useModel(playerState)
-  const expedition = useModel(expeditionState)
+
+  const onPause = useCallback(() => {
+    game.dispatch(pause)
+  }, [game])
+
+  useKeyHandler({
+    Escape: onPause,
+  })
 
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      player.dispatch(endTurn)
-
-      if (Math.random() * 100 < 20) {
-        player.dispatch(dealDamage(1))
-      }
-      expedition.dispatch(endExpeditionTurn)
-    }, 100)
-
     if (isComplete) {
       navigateTo('expedition-ended')
     }
-
-    return () => {
-      clearTimeout(timeout)
-    }
-  }, [expedition, isComplete, navigateTo, player])
+  }, [isComplete, navigateTo])
 
   const status = `Health: ${player.health}/${player.healthMax}
-Link  : ${player.link}`
+Link  : ${player.link}
+Paused: ${game.paused}`
 
   return (
     <div className="dungeon-screen">

--- a/src/components/map-panel-pixi.tsx
+++ b/src/components/map-panel-pixi.tsx
@@ -49,10 +49,16 @@ export const MapPanel = () => {
 
   const appRef = useRef<PIXI.Application | null>(null)
 
-  const handleTick = useRecoilCallback(({ set, snapshot }) => () => {
+  const handleTick = useRecoilCallback(({ set, snapshot }) => (delta: number) => {
     const paused = snapshot.getLoadable(gameState).valueOrThrow().paused
 
     if (paused) {
+      return
+    }
+
+    timeSinceScrollRef.current += delta
+
+    if (timeSinceScrollRef.current < (1000 / 100)) {
       return
     }
 
@@ -110,13 +116,7 @@ export const MapPanel = () => {
       }
     }
 
-    app.ticker.add((delta) => {
-      timeSinceScrollRef.current += delta
-
-      if (timeSinceScrollRef.current > (1000 / 100)) {
-        handleTick()
-      }
-    })
+    app.ticker.add(handleTick)
 
     appRef.current = app
   }, [handleTick])

--- a/src/components/panel.css
+++ b/src/components/panel.css
@@ -13,8 +13,8 @@
 .content {
   flex: 1;
   font-family: VT323;
-  font-size: 24px;
-  line-height: 24px;
+  font-size: 16px;
+  line-height: 16px;
   margin: 8px;
   overflow: hidden;
 }

--- a/src/components/popup-menu.css
+++ b/src/components/popup-menu.css
@@ -1,0 +1,11 @@
+.popup-menu {
+  background-color: black;
+  border: 2px solid silver;
+  left: 50%;
+  max-width: 50%;
+  padding: 96px;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 800px;
+}

--- a/src/components/popup-menu.tsx
+++ b/src/components/popup-menu.tsx
@@ -1,0 +1,11 @@
+import { ScreenMenu, ScreenMenuProps } from './screen-menu'
+
+import './popup-menu.css'
+
+export const PopupMenu = (props: ScreenMenuProps) => {
+  return (
+    <div className="popup-menu">
+      <ScreenMenu {...props} />
+    </div>
+  )
+}

--- a/src/components/screen-menu.css
+++ b/src/components/screen-menu.css
@@ -1,0 +1,18 @@
+.screen-menu {
+  margin: 0;
+  padding: 0;
+  text-align: center;
+}
+.screen-menu:focus { outline: none; }
+
+.screen-menu li {
+  font-size: 72px;
+  list-style-type: none;
+  margin: 0 0 48px 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+.screen-menu li:last-child {
+  margin-bottom: 0;
+}

--- a/src/components/screen-menu.tsx
+++ b/src/components/screen-menu.tsx
@@ -1,0 +1,103 @@
+import { findIndex, map, noop } from 'lodash/fp'
+import React, { useCallback, useState } from 'react'
+
+import './screen-menu.css'
+
+export interface ScreenMenuProps {
+  /** the item to select when the list first renders */
+  initialSelection?: string
+
+  items: string[]
+
+  /** called when the user selects an item, but has not confirmed */
+  onItemSelected?: (item: string) => void
+
+  /** called when a user confirms a selection, with 'enter' or clciking */
+  onSelectionConfirmed?: (item: string) => void
+}
+
+export const ScreenMenu = ({
+  initialSelection,
+  items,
+  onItemSelected = noop,
+  onSelectionConfirmed = noop,
+}: ScreenMenuProps) => {
+  const [selectedItem, setSelectedItem] = useState(initialSelection ?? items[0])
+
+  // update the focus when a new UL element is created
+  const refCallback = useCallback((ul: HTMLUListElement) => {
+    ul?.focus()
+  }, [])
+
+  // handle blur events by taking focus back
+  // works on this screen, because we only have one element that we want to handle input
+  const handleBlur = useCallback((event: React.FocusEvent<HTMLUListElement>) => {
+    event.target.focus()
+  }, [])
+
+  // notify listeners of a selection change, and update UI
+  const select = useCallback((item: string) => {
+    onItemSelected(item)
+    setSelectedItem(item)
+  }, [onItemSelected, setSelectedItem])
+
+  // notify listeners the user has confirmed their choice
+  const confirmSelection = useCallback((item: string) => {
+    onSelectionConfirmed(item)
+  }, [onSelectionConfirmed])
+
+  // navigate the menu via arrow keys
+  const handleKeyPress = useCallback((event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowDown': {
+        const index = findIndex((item) => item === selectedItem, items)
+        const nextIndex = (index + 1) % items.length
+        select(items[nextIndex])
+        break
+      }
+
+      case 'ArrowUp': {
+        const index = findIndex((item) => item === selectedItem, items)
+        const nextIndex = index === 0 ? items.length - 1 : index - 1
+        select(items[nextIndex])
+        break
+      }
+
+      case 'Enter':
+        confirmSelection(selectedItem)
+        break
+    }
+  }, [confirmSelection, items, select, selectedItem])
+
+  // navigate the menu via mouse
+  const handleHover = useCallback((item: string) => () => {
+    select(item)
+  }, [select])
+
+  // confirm selection by clicking
+  const handleClick = useCallback((item: string) => () => {
+    select(item)
+    confirmSelection(item)
+  }, [confirmSelection, select])
+
+  return (
+    <ul
+      className="screen-menu"
+      onBlur={handleBlur}
+      onKeyDown={handleKeyPress}
+      ref={refCallback}
+      tabIndex={0}
+    >
+      {map((name: string) => (
+        <li
+          key={name}
+          className={selectedItem === name ? 'animated-option' : ''}
+          onMouseEnter={handleHover(name)}
+          onClick={handleClick(name)}
+        >
+          {name}
+        </li>
+      ), items)}
+    </ul>
+  )
+}

--- a/src/components/title-screen.css
+++ b/src/components/title-screen.css
@@ -2,38 +2,6 @@
   font-family: VT323;
   font-size: 20em;
   letter-spacing: 0.05em;
-  margin: 64px 0 32px 0;
+  margin: 64px 0 96px 0;
   text-align: center;
-}
-
-.screen-menu {
-  border-top: 2px solid gray;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 64px 0 0 0;
-  text-align: center;
-  width: 450px;
-}
-.screen-menu:focus { outline: none; }
-
-.screen-menu li {
-  font-size: 72px;
-  list-style-type: none;
-  margin: 0 0 48px 0;
-  padding: 0;
-  cursor: pointer;
-}
-
-
-@keyframes breathing {
-  from {
-    letter-spacing: 0;
-  }
-  to {
-    letter-spacing: 0.75px;
-  }
-}
-
-.screen-menu li:last-child {
-  margin-bottom: 0;
 }

--- a/src/components/title-screen.tsx
+++ b/src/components/title-screen.tsx
@@ -1,7 +1,5 @@
-import { findIndex, map, noop } from 'lodash/fp'
-import React, { useCallback, useState } from 'react'
-
 import { ScreenName } from './app'
+import { ScreenMenu } from './screen-menu'
 import './title-screen.css'
 
 export interface TitleScreenProps {
@@ -12,110 +10,11 @@ export interface TitleScreenProps {
   navigateTo: (screen: ScreenName) => void
 }
 
-interface MenuProps {
-  /** the item to select when the list first renders */
-  initialSelection?: string
-
-  items: string[]
-
-  /** called when the user selects an item, but has not confirmed */
-  onItemSelected?: (item: string) => void
-
-  /** called when a user confirms a selection, with 'enter' or clciking */
-  onSelectionConfirmed?: (item: string) => void
-}
-
-const Menu = ({
-  initialSelection,
-  items,
-  onItemSelected = noop,
-  onSelectionConfirmed = noop,
-}: MenuProps) => {
-  const [selectedItem, setSelectedItem] = useState(initialSelection ?? items[0])
-
-  // update the focus when a new UL element is created
-  const refCallback = useCallback((ul: HTMLUListElement) => {
-    ul?.focus()
-  }, [])
-
-  // handle blur events by taking focus back
-  // works on this screen, because we only have one element that we want to handle input
-  const handleBlur = useCallback((event: React.FocusEvent<HTMLUListElement>) => {
-    event.target.focus()
-  }, [])
-
-  // notify listeners of a selection change, and update UI
-  const select = useCallback((item: string) => {
-    onItemSelected(item)
-    setSelectedItem(item)
-  }, [onItemSelected, setSelectedItem])
-
-  // notify listeners the user has confirmed their choice
-  const confirmSelection = useCallback((item: string) => {
-    onSelectionConfirmed(item)
-  }, [onSelectionConfirmed])
-
-  // navigate the menu via arrow keys
-  const handleKeyPress = useCallback((event: React.KeyboardEvent) => {
-    switch (event.key) {
-      case 'ArrowDown': {
-        const index = findIndex((item) => item === selectedItem, items)
-        const nextIndex = (index + 1) % items.length
-        select(items[nextIndex])
-        break
-      }
-
-      case 'ArrowUp': {
-        const index = findIndex((item) => item === selectedItem, items)
-        const nextIndex = index === 0 ? items.length - 1 : index - 1
-        select(items[nextIndex])
-        break
-      }
-
-      case 'Enter':
-        confirmSelection(selectedItem)
-        break
-    }
-  }, [confirmSelection, items, select, selectedItem])
-
-  // navigate the menu via mouse
-  const handleHover = useCallback((item: string) => () => {
-    select(item)
-  }, [select])
-
-  // confirm selection by clicking
-  const handleClick = useCallback((item: string) => () => {
-    select(item)
-    confirmSelection(item)
-  }, [confirmSelection, select])
-
-  return (
-    <ul
-      className="screen-menu"
-      onBlur={handleBlur}
-      onKeyDown={handleKeyPress}
-      ref={refCallback}
-      tabIndex={0}
-    >
-      {map((name: string) => (
-        <li
-          key={name}
-          className={selectedItem === name ? 'animated-option' : ''}
-          onMouseEnter={handleHover(name)}
-          onClick={handleClick(name)}
-        >
-          {name}
-        </li>
-      ), items)}
-    </ul>
-  )
-}
-
 export const TitleScreen = ({ exit, navigateTo }: TitleScreenProps) => {
   return (
     <>
       <h1 className="game-title">Shift</h1>
-      <Menu
+      <ScreenMenu
         items={['New Game', 'Exit']}
         onSelectionConfirmed={(item) => {
           switch (item) {

--- a/src/hooks/use-key-handler.ts
+++ b/src/hooks/use-key-handler.ts
@@ -1,0 +1,22 @@
+import { noop } from 'lodash/fp'
+import { useCallback, useEffect } from 'react'
+
+/**
+ * Registers a 'keydown' handler on the window, and unregisters it when the component is unmounted.
+ * The handler will dispatch to one of a set of key handlers whenever a key is pressed. The handlers
+ * are provided via the `handlerMap`. The map keys are the key values (i.e. `event.key`), and the
+ * value is a no-arg function that will be called when that key is pressed.
+ */
+export const useKeyHandler = (handlerMap: Record<string, () => void>) => {
+  const handler = useCallback((event: KeyboardEvent) => {
+    const keyHandler = handlerMap[event.key] ?? noop
+    keyHandler()
+  }, [handlerMap])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handler)
+    return () => {
+      window.removeEventListener('keydown', handler)
+    }
+  }, [handler])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,14 @@ body {
   color: white;
 }
 
+@keyframes breathing {
+  from {
+    letter-spacing: 0;
+  }
+  to {
+    letter-spacing: 0.75px;
+  }
+}
 .animated-option:after { 
   content: ' <'; 
 }

--- a/src/state/game.ts
+++ b/src/state/game.ts
@@ -1,0 +1,26 @@
+import { atom } from 'recoil'
+
+/** State of the game itself, such as the active screen, pause state, etc. */
+export interface Game {
+  /** whether the game has been paused or not */
+  paused: boolean
+}
+
+export const newGame = (): Game => ({
+  paused: false,
+})
+
+export const gameState = atom<Game>({
+  key: 'gameState',
+  default: newGame(),
+})
+
+export const pause = (game: Game): Game => ({
+  ...game,
+  paused: true,
+})
+
+export const unpause = (game: Game): Game => ({
+  ...game,
+  paused: false,
+})

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,11 +1,11 @@
+import { useCallback } from 'react'
 import { RecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
 
 export type Dispatch<T> = (action: (state: T) => T) => void
 
 export const useDispatch = <T>(state: RecoilState<T>) => {
   const setter = useSetRecoilState(state)
-
-  return (action: (state: T) => T) => setter(action)
+  return useCallback((action: (state: T) => T) => setter(action), [setter])
 }
 
 export const useModel = <T>(state: RecoilState<T>): T & { dispatch: Dispatch<T> } => {


### PR DESCRIPTION
- Memoize useDispatch result when possible.
- Add useKeyHandler hook for working with global key events.
- Add game state, with initial 'paused' property.
- Add 'pause' key handling to expedition screen.
- Increase panel font size to enhance readability.
- Restructure pixi map panel.
- Extract ScreenMenu component out of title screen.
- Add PopupMenu component.
- Implement pause menu, with 'Resume' and 'Quit' options.

Closes #36 
