### PR TITLE
feat: add equipment effects and UI

### DIFF
--- a/src/engine/container.test.ts
+++ b/src/engine/container.test.ts
@@ -4,8 +4,8 @@ import { Container } from './container'
 import { Item } from './item'
 
 describe('container', () => {
-  const createContainer = () => new Container('test-container')
-  const createItem = () => new Item('test-object')
+  const createContainer = () => new Container({ name: 'test-container' })
+  const createItem = () => new Item({ name: 'test-object' })
 
   let container: Container
   let object1: Item
@@ -46,6 +46,17 @@ describe('container', () => {
       expect(container.contents.length).toBe(1)
       expect(find((item) => item.id === object1.id, container.contents)).toBeUndefined()
       expect(find((item) => item.id === object2.id, container.contents)).toBeDefined()
+    })
+  })
+
+  describe('contains', () => {
+    test('true', () => {
+      container.add(object1)
+      expect(container.contains(object1)).toBe(true)
+    })
+
+    test('false', () => {
+      expect(container.contains(object1)).toBe(false)
     })
   })
 })

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -28,6 +28,11 @@ export class Container extends Item {
     }
   }
 
+  /** Returns true if the specified item is in this container. */
+  public contains (item: Item) {
+    return findIndex((candidate) => candidate.id === item.id, this._contents) !== -1
+  }
+
   /** The contents of this container, as a readonly array */
   public get contents (): Readonly<Item[]> {
     return this._contents

--- a/src/engine/creature.test.ts
+++ b/src/engine/creature.test.ts
@@ -1,0 +1,86 @@
+import { CreatureTypes } from 'db/creatures'
+import { keys } from 'lodash/fp'
+
+import { Creature } from './creature'
+import { createWeapon, Item } from './item'
+import { ExpeditionMap } from './map'
+
+describe('container', () => {
+  const createCreature = () => new Creature(CreatureTypes['player'], 0, 0, new ExpeditionMap())
+
+  describe('equipment', () => {
+    test('unequippable item', () => {
+      const creature = createCreature()
+      const item = new Item({ name: 'test-item' })
+      creature.inventory.add(item)
+
+      expect(creature.equip(item)).toBe(false)
+      expect(keys(creature.equipment).length).toBe(0)
+    })
+
+    test('invalid slot', () => {
+      const creature = createCreature()
+      const item = createWeapon('test-weapon')
+      creature.inventory.add(item)
+
+      expect(creature.equip(item, 'Body')).toBe(false)
+      expect(keys(creature.equipment).length).toBe(0)
+    })
+
+    test('slot already in use', () => {
+      const creature = createCreature()
+      const item1 = new Item({ name: 'test-body-item-1', equipmentSlots: ['Body'] })
+      const item2 = new Item({ name: 'test-body-item-1', equipmentSlots: ['Body'] })
+      creature.inventory.add(item1)
+      creature.inventory.add(item2)
+
+      creature.equip(item1)
+      expect(creature.equip(item2)).toBe(false)
+      expect(keys(creature.equipment).length).toBe(1)
+      expect(creature.equipment.Body?.id).toBe(item1.id)
+    })
+
+    test('specific slot', () => {
+      const creature = createCreature()
+      const item = createWeapon('test-weapon-1')
+      creature.inventory.add(item)
+
+      expect(creature.equip(item, 'OffHand')).toBe(true)
+      expect(keys(creature.equipment).length).toBe(1)
+      expect(creature.equipment.MainHand).toBeUndefined()
+      expect(creature.equipment.OffHand?.id).toBe(item.id)
+    })
+
+    test('default slot', () => {
+      const creature = createCreature()
+      const item = createWeapon('test-weapon-1')
+      creature.inventory.add(item)
+
+      expect(creature.equip(item)).toBe(true)
+      expect(keys(creature.equipment).length).toBe(1)
+      expect(creature.equipment.MainHand?.id).toBe(item.id)
+    })
+
+    test('default slot, multiple options', () => {
+      const creature = createCreature()
+      const item1 = createWeapon('test-weapon-1')
+      const item2 = createWeapon('test-weapon-2')
+      creature.inventory.add(item1)
+      creature.inventory.add(item2)
+
+      creature.equip(item1)
+      expect(creature.equip(item2)).toBe(true)
+      expect(keys(creature.equipment).length).toBe(2)
+      expect(creature.equipment.MainHand?.id).toBe(item1.id)
+      expect(creature.equipment.OffHand?.id).toBe(item2.id)
+    })
+
+    test('item not in inventory', () => {
+      const creature = createCreature()
+      const item = createWeapon('test-weapon-1')
+
+      expect(creature.equip(item)).toBe(false)
+      expect(keys(creature.equipment).length).toBe(0)
+    })
+  })
+})

--- a/src/engine/creature.test.ts
+++ b/src/engine/creature.test.ts
@@ -29,8 +29,18 @@ describe('container', () => {
 
     test('slot already in use', () => {
       const creature = createCreature()
-      const item1 = new Item({ name: 'test-body-item-1', equipmentSlots: ['Body'] })
-      const item2 = new Item({ name: 'test-body-item-1', equipmentSlots: ['Body'] })
+      const item1 = new Item({
+        name: 'test-body-item-1',
+        equipment: {
+          slots: ['Body'],
+        },
+      })
+      const item2 = new Item({
+        name: 'test-body-item-2',
+        equipment: {
+          slots: ['Body'],
+        },
+      })
       creature.inventory.add(item1)
       creature.inventory.add(item2)
 

--- a/src/engine/item.ts
+++ b/src/engine/item.ts
@@ -1,5 +1,24 @@
+import { findIndex } from 'lodash/fp'
+
 import { newId } from './new-id'
 import { Entity } from './types'
+
+export const EquipmentSlots = [
+  'Body',
+  'MainHand',
+  'OffHand',
+] as const
+export type EquipmentSlot = (typeof EquipmentSlots)[number]
+
+export type Equipment = Partial<Record<EquipmentSlot, Item>>
+
+export interface ItemOptions {
+  /** the slots in which this item can be equipped, which may be an empty list */
+  equipmentSlots?: EquipmentSlot[]
+
+  /** human-readable name of the item */
+  name: string
+}
 
 /**
  * An Item represents a uniqueable identifiable item in the game world. This could include dungeon
@@ -9,7 +28,29 @@ import { Entity } from './types'
 export class Item implements Entity {
   public readonly id = newId()
 
-  constructor (
-    public readonly name: string
-  ) { /* noop */ }
+  /** the slots in which this item can be equipped, which may be an empty list */
+  public readonly equipmentSlots: EquipmentSlot[]
+
+  public readonly name: string
+
+  constructor ({
+    equipmentSlots = [],
+    name,
+  }: ItemOptions) {
+    this.equipmentSlots = equipmentSlots
+    this.name = name
+  }
+
+  /** flag indicating if this item can be equipped or not */
+  public get equippable () {
+    return this.equipmentSlots.length > 0
+  }
+
+  public equippableIn (slot: EquipmentSlot) {
+    return findIndex((candidate) => candidate === slot, this.equipmentSlots) !== -1
+  }
 }
+
+/** Creates an item with default options for a weapon. */
+export const createWeapon = (name: string) =>
+  new Item({ name, equipmentSlots: ['MainHand', 'OffHand'] })

--- a/src/engine/item.ts
+++ b/src/engine/item.ts
@@ -18,6 +18,9 @@ export interface EquipmentEffects {
 }
 
 export interface ItemOptions {
+  /** optional detailed description for the item */
+  description?: string
+
   /** optional configuration for equippable items */
   equipment?: {
     /** the effects on the wearer when this item is equipped */
@@ -45,14 +48,20 @@ export class Item implements Entity {
   /** the effects of wearing this equipment, which may be undefined */
   public readonly equipmentEffects: EquipmentEffects | undefined
 
+  /** detailed description */
+  public readonly description: string | undefined
+
+  /** name of this item */
   public readonly name: string
 
   constructor ({
     equipment,
     name,
+    description,
   }: ItemOptions) {
     this.equipmentSlots = equipment?.slots ?? []
     this.equipmentEffects = equipment?.effects
+    this.description = description
     this.name = name
   }
 
@@ -85,8 +94,9 @@ export const createWeapon = (name: string, meleeBonus = 0) =>
   })
 
 /** Creates an item with default options for armo. */
-export const createArmor = (name: string, defenseBonus = 0) =>
+export const createArmor = (name: string, defenseBonus = 0, description?: string) =>
   new Item({
+    description,
     equipment: {
       effects: {
         attributeModifiers: {

--- a/src/engine/item.ts
+++ b/src/engine/item.ts
@@ -1,6 +1,6 @@
 import { findIndex } from 'lodash/fp'
 
-import { Creature } from './creature'
+import { CreatureAttributeModifiers } from './creature'
 import { newId } from './new-id'
 import { Entity } from './types'
 
@@ -14,15 +14,7 @@ export type EquipmentSlot = (typeof EquipmentSlots)[number]
 export type EquipmentSet = Partial<Record<EquipmentSlot, Item>>
 
 export interface EquipmentEffects {
-  /**
-   * Optional method that returns a modifier to the wearer's "defense" score.
-   **/
-  defenseModifier?: (wearer: Creature) => number
-
-  /**
-   * Optional method that returns a modifier to the wearer's "melee" score.
-   **/
-  meleeModifier?: (wearer: Creature) => number
+  attributeModifiers?: CreatureAttributeModifiers
 }
 
 export interface ItemOptions {
@@ -83,7 +75,9 @@ export const createWeapon = (name: string, meleeBonus = 0) =>
   new Item({
     equipment: {
       effects: {
-        meleeModifier: () => meleeBonus,
+        attributeModifiers: {
+          modifyMelee: (value) => value + meleeBonus,
+        },
       },
       slots: ['MainHand', 'OffHand'],
     },
@@ -95,7 +89,9 @@ export const createArmor = (name: string, defenseBonus = 0) =>
   new Item({
     equipment: {
       effects: {
-        defenseModifier: () => defenseBonus,
+        attributeModifiers: {
+          modifyDefense: (value) => value + defenseBonus,
+        },
       },
       slots: ['Body'],
     },

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -8,7 +8,7 @@ import { AttackResult } from './combat'
 import { createPrototypeTerrain } from './create-prototype-terrain'
 import { Creature } from './creature'
 import { WorldEvents } from './events'
-import { createWeapon, Item } from './item'
+import { createArmor, createWeapon, Item } from './item'
 import { ExpeditionMap } from './map'
 import { Action } from './types'
 
@@ -29,10 +29,15 @@ export class World extends TypedEventEmitter<WorldEvents> {
     this._player = this.spawn('player', 0, 0)
     this._playerAction = NoopAction
     this._player.inventory.add(new Item({ name: 'a coconut' }))
-    const spear = createWeapon('+1 spear')
-    this._player.inventory.add(spear)
     this._player.inventory.add(new Item({ name: 'hopes and dreams' }))
+
+    const spear = createWeapon('+100 spear', 100)
+    this._player.inventory.add(spear)
     this._player.equip(spear)
+
+    const armor = createArmor('amazing, glowing armor', 100)
+    this._player.inventory.add(armor)
+    this._player.equip(armor)
 
     this.spawn('kobold', -20, 0)
     this.spawn('kobold', -22, 0)

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -35,7 +35,10 @@ export class World extends TypedEventEmitter<WorldEvents> {
     this._player.inventory.add(spear)
     // this._player.equip(spear)
 
-    const armor = createArmor('amazing, glowing armor', 100)
+    const armor = createArmor('amazing, glowing armor', 100, `Lorem ipsum dolor sit amet, 
+consectetur adipiscing elit. Aenean pharetra est id velit laoreet, eu semper lectus ullamcorper.
+Nunc pellentesque nunc ex, eu venenatis orci mattis non. Maecenas in justo mollis, luctus urna 
+porttitor, imperdiet lectus. Quisque sit amet quam venenatis, iaculis sapien in, rutrum dui.`)
     this._player.inventory.add(armor)
     // this._player.equip(armor)
 

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -8,7 +8,7 @@ import { AttackResult } from './combat'
 import { createPrototypeTerrain } from './create-prototype-terrain'
 import { Creature } from './creature'
 import { WorldEvents } from './events'
-import { Item } from './item'
+import { createWeapon, Item } from './item'
 import { ExpeditionMap } from './map'
 import { Action } from './types'
 
@@ -28,9 +28,11 @@ export class World extends TypedEventEmitter<WorldEvents> {
     createPrototypeTerrain(this.map)
     this._player = this.spawn('player', 0, 0)
     this._playerAction = NoopAction
-    this._player.inventory.add(new Item('a coconut'))
-    this._player.inventory.add(new Item('+1 spear'))
-    this._player.inventory.add(new Item('hopes and dreams'))
+    this._player.inventory.add(new Item({ name: 'a coconut' }))
+    const spear = createWeapon('+1 spear')
+    this._player.inventory.add(spear)
+    this._player.inventory.add(new Item({ name: 'hopes and dreams' }))
+    this._player.equip(spear)
 
     this.spawn('kobold', -20, 0)
     this.spawn('kobold', -22, 0)

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -33,11 +33,11 @@ export class World extends TypedEventEmitter<WorldEvents> {
 
     const spear = createWeapon('+100 spear', 100)
     this._player.inventory.add(spear)
-    this._player.equip(spear)
+    // this._player.equip(spear)
 
     const armor = createArmor('amazing, glowing armor', 100)
     this._player.inventory.add(armor)
-    this._player.equip(armor)
+    // this._player.equip(armor)
 
     this.spawn('kobold', -20, 0)
     this.spawn('kobold', -22, 0)

--- a/src/ui/components/expedition-ended-screen.tsx
+++ b/src/ui/components/expedition-ended-screen.tsx
@@ -36,7 +36,7 @@ export const ExpeditionEndedScreen = ({ navigateTo }: ExpeditionEndedScreenProps
     navigateTo('title')
   }, [resetExpedition, resetPlayer, navigateTo])
 
-  const fate = player.health < 1 ? 'was killed' : 'lost his connection to this world'
+  const fate = player.dead ? 'was killed' : 'lost his connection to this world'
 
   const expeditionSummary =
     `${player.name} ${fate}.

--- a/src/ui/components/expedition-screen.css
+++ b/src/ui/components/expedition-screen.css
@@ -8,7 +8,7 @@
   display: flex;
   flex: 1 1;
   flex-direction: column;
-  margin: 16px 16px 16px 0;
+  margin: 16px 0 16px 16px;
   overflow: hidden;
 }
 

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -12,6 +12,7 @@ import { fromEntity, playerState } from 'ui/state/player'
 
 import { ScreenName } from './app'
 import { ContainerContentsPanel } from './container-contents-panel'
+import { ListPanel } from './list-panel'
 import { LogPanel } from './log-panel'
 import { MapPanel } from './map-panel'
 import { Panel } from './panel'
@@ -20,13 +21,14 @@ import { PopupMenu } from './popup-menu'
 
 import './expedition-screen.css'
 
-const SidebarColumns = 30
+const SidebarColumns = 45
 
 enum SelectablePanels {
-  Information = 0,
-  Map,
+  Map = 0,
+  Information,
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __LENGTH,
+  Options,
 }
 
 export interface ExpeditionScreenProps {
@@ -190,6 +192,22 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
 
   return (ready && world.current) ? (
     <div className="dungeon-screen">
+      {world.current &&
+        <div className="main-content">
+          <MapPanel
+            active={activePanel === SelectablePanels.Map && !game.paused}
+            centerX={viewportCenter.x}
+            centerY={viewportCenter.y}
+            onClick={handleActivatePanel(SelectablePanels.Map)}
+            onKeyDown={mapKeyHandler}
+            onViewportSizeChanged={handleViewportResize}
+            world={world.current}
+          />
+
+          <LogPanel world={world.current} />
+        </div>
+      }
+
       <div className="sidebar">
         <PlayerStatusPanel />
 
@@ -209,29 +227,21 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
           columns={SidebarColumns}
           container={world.current.player.inventory}
           onClick={handleActivatePanel(SelectablePanels.Information)}
-        >
-        </ContainerContentsPanel>
+          title="Inventory"
+        />
+
+        <ListPanel
+          active={activePanel === SelectablePanels.Options && !game.paused}
+          allowSelection={true}
+          columns={SidebarColumns}
+          items={['Drop', 'Equip', 'Unequip']}
+          rows={3}
+        />
 
         <Panel columns={SidebarColumns} rows={8}>
           Lorem ipsum dolor sit amet.
         </Panel>
       </div>
-
-      {world.current &&
-        <div className="main-content">
-          <MapPanel
-            active={activePanel === SelectablePanels.Map && !game.paused}
-            centerX={viewportCenter.x}
-            centerY={viewportCenter.y}
-            onClick={handleActivatePanel(SelectablePanels.Map)}
-            onKeyDown={mapKeyHandler}
-            onViewportSizeChanged={handleViewportResize}
-            world={world.current}
-          />
-
-          <LogPanel world={world.current} />
-        </div>
-      }
 
       {game.paused ? renderPauseMenu() : null}
     </div>

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -8,7 +8,7 @@ import { useGlobalKeyHandler } from 'ui/hooks/use-global-key-handler'
 import { useKeyHandler } from 'ui/hooks/use-key-handler'
 import { endTurn, expeditionState, isExpeditionComplete } from 'ui/state/expedition'
 import { gameState, pause, unpause } from 'ui/state/game'
-import { playerState } from 'ui/state/player'
+import { fromEntity, playerState } from 'ui/state/player'
 
 import { ScreenName } from './app'
 import { ContainerContentsPanel } from './container-contents-panel'
@@ -17,7 +17,6 @@ import { MapPanel } from './map-panel'
 import { Panel } from './panel'
 import { PlayerStatusPanel } from './player-status-panel'
 import { PopupMenu } from './popup-menu'
-import { PreFormattedText } from './pre-formatted-text'
 
 import './expedition-screen.css'
 
@@ -42,7 +41,6 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
 
   const resetExpedition = useResetRecoilState(expeditionState)
   const resetGame = useResetRecoilState(gameState)
-  const resetPlayer = useResetRecoilState(playerState)
 
   const updateExpedition = useSetRecoilState(expeditionState)
   const updatePlayer = useSetRecoilState(playerState)
@@ -56,9 +54,9 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
     world.current = new World()
     resetExpedition()
     resetGame()
-    resetPlayer()
+    updatePlayer(fromEntity(world.current.player))
     setReady(true)
-  }, [resetExpedition, resetGame, resetPlayer])
+  }, [resetExpedition, resetGame, updatePlayer])
 
   const handleActivatePanel = useCallback((panel: SelectablePanels) => () => {
     setActivePanel(panel)
@@ -132,18 +130,9 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
 
       // update our recoil state based on the new world state
       updateExpedition(endTurn)
-      updatePlayer((player) => {
-        if (world.current) {
-          const worldPlayer = world.current?.player
-          return {
-            ...player,
-            health: worldPlayer.health,
-          }
-        }
+      updatePlayer(fromEntity(world.current.player))
 
-        return player
-      })
-
+      // recenter viewport based on player movement, if needed
       updateViewport(viewportSize, viewportCenter)
     }
   }, [game.paused, updateExpedition, updatePlayer, updateViewport, viewportCenter, viewportSize])
@@ -204,7 +193,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
       <div className="sidebar">
         <PlayerStatusPanel />
 
-        <Panel columns={SidebarColumns} rows={5}>
+        {/* <Panel columns={SidebarColumns} rows={5}>
           <PreFormattedText>{`You attack kobold!
 
 🗡️ x5: 2  1  0  1  0  1
@@ -212,7 +201,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
 💔 -2
 
 🛡️ x3 - 0  1  0`}</PreFormattedText>
-        </Panel>
+        </Panel> */}
 
         <ContainerContentsPanel
           active={activePanel === SelectablePanels.Information && !game.paused}

--- a/src/ui/components/inventory-panel.css
+++ b/src/ui/components/inventory-panel.css
@@ -1,0 +1,4 @@
+.inventory-panel-item-description {
+  margin: 4px 0;
+  padding: 0;
+}

--- a/src/ui/components/inventory-panel.tsx
+++ b/src/ui/components/inventory-panel.tsx
@@ -1,0 +1,67 @@
+import { Item } from 'engine/item'
+import { find, get, head, map } from 'lodash/fp'
+import { useCallback, useEffect, useState } from 'react'
+import { useRecoilValue } from 'recoil'
+import { playerState } from 'ui/state/player'
+
+import { ContainerContentsPanel } from './container-contents-panel'
+import { ListPanel, ListPanelProps } from './list-panel'
+
+export type ItemAction = {
+  /** name of this action, to display in the list */
+  name: string
+
+  /** invoke the action, for the given item */
+  execute: (item: Item) => void
+}
+
+export type InventoryPanelProps = Omit<
+ListPanelProps, 'items' | 'title' | 'container' | 'onItemConsidered' | 'onItemSelected'
+> & {
+  /** given an item in the inventory, return a set of actions the user can perform on that item */
+  getItemActions: (item: Item) => ItemAction[]
+}
+
+export const InventoryPanel = ({
+  active,
+  getItemActions,
+  ...rest
+}: InventoryPanelProps) => {
+  const player = useRecoilValue(playerState)
+  const [selectedItem, setSelectedItem] = useState(head(player.inventory.contents))
+
+  // if the user tabs out of the list, clear the item selection to avoid confusion
+  useEffect(() => {
+    if (!active) {
+      setSelectedItem(undefined)
+    }
+  }, [active])
+
+  const handleItemAction = useCallback((action: string) => {
+    if (selectedItem !== undefined) {
+      find(
+        (availableAction) => availableAction.name === action,
+        getItemActions(selectedItem)
+      )?.execute(selectedItem)
+    }
+
+    setSelectedItem(undefined)
+  }, [getItemActions, selectedItem])
+
+  return selectedItem === undefined ? (
+    <ContainerContentsPanel {...rest}
+      active={active}
+      container={player.inventory}
+      onItemSelected={setSelectedItem}
+      title="Inventory"
+    />
+  ) : (
+    <ListPanel {...rest}
+      active={active}
+      allowSelection={true}
+      items={[...map(get('name'), getItemActions(selectedItem)), 'Back']}
+      onItemSelected={handleItemAction}
+      title={selectedItem.name}
+    />
+  )
+}

--- a/src/ui/components/inventory-panel.tsx
+++ b/src/ui/components/inventory-panel.tsx
@@ -7,6 +7,8 @@ import { playerState } from 'ui/state/player'
 import { ContainerContentsPanel } from './container-contents-panel'
 import { ListPanel, ListPanelProps } from './list-panel'
 
+import './inventory-panel.css'
+
 export type ItemAction = {
   /** name of this action, to display in the list */
   name: string
@@ -62,6 +64,10 @@ export const InventoryPanel = ({
       items={[...map(get('name'), getItemActions(selectedItem)), 'Back']}
       onItemSelected={handleItemAction}
       title={selectedItem.name}
-    />
+    >
+      {selectedItem?.description &&
+        <p className="inventory-panel-item-description">{selectedItem.description}</p>
+      }
+    </ListPanel>
   )
 }

--- a/src/ui/components/list-panel.css
+++ b/src/ui/components/list-panel.css
@@ -1,7 +1,27 @@
+.list-panel {
+  margin: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.list-panel-title {
+  background-color: #222;
+  border: 1px solid #333;
+  font-size: 1em;
+  margin: 0 0 6px 0;
+  padding: 2px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
 .list-panel-row {
   cursor: pointer;
   display: flex;
   flex-direction: row;
+  list-style-type: none;
+  margin: 0;
+  padding: 0
 }
 
 .list-panel-row.selectable:before {

--- a/src/ui/components/list-panel.css
+++ b/src/ui/components/list-panel.css
@@ -1,5 +1,5 @@
 .list-panel {
-  margin: 0;
+  margin: 4px 0 0 0;
   overflow-x: hidden;
   overflow-y: auto;
   padding: 0;
@@ -32,7 +32,7 @@
   content: '>\00a0';
 }
 
-.list-panel-row.selected {
+.list-panel-row.selected, .list-panel-row:hover {
   color: #aa0;
 }
 

--- a/src/ui/components/list-panel.tsx
+++ b/src/ui/components/list-panel.tsx
@@ -50,6 +50,7 @@ export interface ListPanelProps extends PanelProps {
 export const ListPanel = ({
   active = false,
   allowSelection,
+  children,
   items,
   onItemConsidered = noop,
   onItemSelected = noop,
@@ -127,6 +128,7 @@ export const ListPanel = ({
       onKeyDown={handleKeyDown}
     >
       {title && <h2 className="list-panel-title">{title}</h2>}
+      {children}
       <ul className="list-panel">
         {mapS(items, createRow)}
       </ul>

--- a/src/ui/components/list-panel.tsx
+++ b/src/ui/components/list-panel.tsx
@@ -53,6 +53,7 @@ export const ListPanel = ({
   items,
   onItemConsidered = noop,
   onItemSelected = noop,
+  title,
   ...rest
 }: ListPanelProps) => {
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -110,13 +111,13 @@ export const ListPanel = ({
     ])
 
     return (
-      <div key={getId(item)}
+      <li key={getId(item)}
         className={classes}
         onClick={handleClick(index)}
       >
         <div className="list-panel-left">{getLeftContent(item)}</div>
         {rightContent && <div className="list-panel-right">{rightContent}</div> }
-      </div>
+      </li>
     )
   }
 
@@ -125,7 +126,10 @@ export const ListPanel = ({
       active={active}
       onKeyDown={handleKeyDown}
     >
-      {mapS(items, createRow)}
+      {title && <h2 className="list-panel-title">{title}</h2>}
+      <ul className="list-panel">
+        {mapS(items, createRow)}
+      </ul>
     </Panel>
   )
 }

--- a/src/ui/components/panel.css
+++ b/src/ui/components/panel.css
@@ -21,8 +21,8 @@
   flex: 1;
   flex-direction: column;
   font-family: VT323;
-  font-size: 16px;
-  line-height: 16px;
+  font-size: 20px;
+  line-height: 20px;
   margin: 8px;
   overflow: hidden;
 }

--- a/src/ui/components/panel.css
+++ b/src/ui/components/panel.css
@@ -17,7 +17,9 @@
 }
 
 .content {
+  display: flex;
   flex: 1;
+  flex-direction: column;
   font-family: VT323;
   font-size: 16px;
   line-height: 16px;

--- a/src/ui/components/panel.tsx
+++ b/src/ui/components/panel.tsx
@@ -6,6 +6,8 @@ import './panel.css'
 
 type InheritedProps = Omit<HTMLAttributes<HTMLDivElement>, 'className'>
 
+const LINE_HEIGHT = 20
+
 export type PanelProps = InheritedProps & PropsWithChildren<{
   /** indicates if this panel is active -- that is, highlighted and receives input */
   active?: boolean
@@ -52,7 +54,7 @@ export const Panel = ({
     containerClasses.push(containerClass)
   }
 
-  const height = rows !== undefined ? rows * 16 : undefined
+  const height = rows !== undefined ? rows * LINE_HEIGHT : undefined
   const width = columns !== undefined ? `${columns}ch` : undefined
 
   return (

--- a/src/ui/components/player-status-panel.tsx
+++ b/src/ui/components/player-status-panel.tsx
@@ -13,10 +13,10 @@ export const PlayerStatusPanel = (props: Omit<PanelProps, 'rows'>) => {
 Health : ${player.health}/${player.healthMax}
 Link   : ${Math.floor(expedition.link / InitialLinkValue * 100)}%
 
+Defense: WRONG!
 Melee  : ${player.melee}
 Missile: 1?
 Focus  : 1?
-
 Turn   : ${expedition.turn}
 `
 

--- a/src/ui/components/player-status-panel.tsx
+++ b/src/ui/components/player-status-panel.tsx
@@ -10,18 +10,20 @@ export const PlayerStatusPanel = (props: Omit<PanelProps, 'rows'>) => {
   const player = useRecoilValue(playerState)
 
   const status = `${player.name} - Level X (0/100?)
+
 Health : ${player.health}/${player.healthMax}
 Link   : ${Math.floor(expedition.link / InitialLinkValue * 100)}%
 
-Defense: WRONG!
+Defense: ${player.defense}
 Melee  : ${player.melee}
-Missile: 1?
-Focus  : 1?
+Missile: undefined
+Focus  : undefined
+
 Turn   : ${expedition.turn}
 `
 
   return (
-    <Panel {...props} rows={9}>
+    <Panel {...props} rows={11}>
       <PreFormattedText>{status}</PreFormattedText>
     </Panel>
   )

--- a/src/ui/state/expedition.ts
+++ b/src/ui/state/expedition.ts
@@ -33,6 +33,6 @@ export const isExpeditionComplete = selector({
   get: ({ get }) => {
     const expedition = get(expeditionState)
     const player = get(playerState)
-    return expedition.link < 1 || player.health < 1
+    return expedition.link < 1 || player.dead
   },
 })

--- a/src/ui/state/player.ts
+++ b/src/ui/state/player.ts
@@ -1,10 +1,12 @@
-import { CreatureAttributes, CreatureAttributeSet } from 'engine/creature'
-import { Player as PlayerEntity } from 'engine/player'
+import { Container } from 'engine/container'
+import { CreatureAttributes, CreatureAttributeSet, Creature as PlayerEntity } from 'engine/creature'
 import { Damageable, Entity, Positionable } from 'engine/types'
 import { pick } from 'lodash/fp'
 import { atom } from 'recoil'
 
-export type Player = Pick<Damageable, 'dead'> & Entity & CreatureAttributeSet & Positionable
+export type Player = Pick<Damageable, 'dead'> & Entity & CreatureAttributeSet & Positionable & {
+  inventory: Container
+}
 
 export const emptyPlayer = (): Player => ({
   dead: false,
@@ -12,6 +14,7 @@ export const emptyPlayer = (): Player => ({
   health: 0,
   healthMax: 0,
   id: -1,
+  inventory: new Container({ name: 'empty-inventory' }),
   melee: 0,
   name: 'Unknown Hero',
   x: 0,
@@ -28,6 +31,7 @@ export const fromEntity = (player: PlayerEntity): Player => {
     ...CreatureAttributes,
     'dead',
     'id',
+    'inventory',
     'name',
     'x',
     'y',

--- a/src/ui/state/player.ts
+++ b/src/ui/state/player.ts
@@ -1,22 +1,35 @@
-import { CreatureType, CreatureTypes } from 'db/creatures'
+import { CreatureAttributes, CreatureAttributeSet } from 'engine/creature'
+import { Player as PlayerEntity } from 'engine/player'
+import { Damageable, Entity, Positionable } from 'engine/types'
+import { pick } from 'lodash/fp'
 import { atom } from 'recoil'
 
-export interface Player extends CreatureType {
-  /** player's current health */
-  health: number
-}
+export type Player = Pick<Damageable, 'dead'> & Entity & CreatureAttributeSet & Positionable
 
-export const newPlayer = (): Player => ({
-  ...CreatureTypes.player,
-  health: 10,
+export const emptyPlayer = (): Player => ({
+  dead: false,
+  defense: 0,
+  health: 0,
+  healthMax: 0,
+  id: -1,
+  melee: 0,
+  name: 'Unknown Hero',
+  x: 0,
+  y: 0,
 })
 
 export const playerState = atom<Player>({
   key: 'playerState',
-  default: newPlayer(),
+  default: emptyPlayer(),
 })
 
-export const dealDamage = (amount: number) => (player: Player): Player => ({
-  ...player,
-  health: player.health - amount,
-})
+export const fromEntity = (player: PlayerEntity): Player => {
+  return pick([
+    ...CreatureAttributes,
+    'dead',
+    'id',
+    'name',
+    'x',
+    'y',
+  ], player)
+}


### PR DESCRIPTION
- Add equipment data model.
- Add ability for equipment to modify melee and defense stats.
- Add ability for equipment to modify creature attributes.
- Update player UI state based on player entity.
- Add title and scrolling to ListPanel.
- Move sidebar to right and increase its width. Add inventory title.
- Add panel for displaying inventory and associated item actions.
- Implement ability to equip items from the inventory panel.
- Add description to item menu panel.
- Visual enhancements: font size, and hover effect on list panels.
