### PR TITLE
fix: monsters were attacking a turn too early

### DIFF
--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -1,6 +1,6 @@
 import { CreatureTypes } from 'db/creatures'
 import { map as mapI } from 'lodash'
-import { filter, forEach, join, omit, values } from 'lodash/fp'
+import { compact, filter, forEach, join, map, omit, values } from 'lodash/fp'
 import { TypedEventEmitter } from 'typed-event-emitter'
 
 import { NoopAction } from './actions/noop'
@@ -71,10 +71,11 @@ porttitor, imperdiet lectus. Quisque sit amet quam venenatis, iaculis sapien in,
   public nextTurn (playerAction: Action) {
     this._playerAction = playerAction
 
-    // iterate over each creature, and execute the action determined by its behavior
-    forEach((creature) => {
-      creature.type.behavior(creature, this)?.(this)
-    }, this.creatures)
+    // iterate over each creature, and get the action determined by its behavior
+    const actions = map((creature) => creature.type.behavior(creature, this), this.creatures)
+
+    // once all actions have been determined, execute them
+    forEach((action) => action(this), compact(actions))
 
     // remove any dead creatures
     const deadCreatures = filter((creature) => creature.dead, values(this.creatures))

--- a/src/ui/components/log-panel.tsx
+++ b/src/ui/components/log-panel.tsx
@@ -17,16 +17,16 @@ export interface LogPanelOptions {
 export const LogPanel = ({ rows = 8, world }: LogPanelOptions) => {
   const [lines, setLines] = useState<string[]>(world.messages)
 
-  const appendMessage = useCallback((message: string) => {
-    setLines((lines) => [...lines, message])
-  }, [])
+  const messageAdded = useCallback(() => {
+    setLines([...world.messages])
+  }, [world.messages])
 
   useEffect(() => {
-    world.on('message', appendMessage)
+    world.on('message', messageAdded)
     return () => {
-      world.off('message', appendMessage)
+      world.off('message', messageAdded)
     }
-  }, [appendMessage, world])
+  }, [messageAdded, world])
 
   let index = 0
 


### PR DESCRIPTION
- Fix issue causing monsters to attack the same turn a player moves in range.
- Fix log panel to avoid sometimes having duplicate messages.
