### PR TITLE
ui: use modal menu for inventory management instead of sidebar

### DIFF
--- a/src/engine/actions/move-by.ts
+++ b/src/engine/actions/move-by.ts
@@ -1,15 +1,34 @@
-import { Action, Moveable } from 'engine/types'
+import { Creature } from 'engine/creature'
+import { Action } from 'engine/types'
+import { World } from 'engine/world'
 
 /** Move the creature a specified distance in each direction. */
 export class MoveByAction implements Action {
   constructor (
-    private _entity: Moveable,
+    private _entity: Creature,
     private _x: number,
     private _y: number) { }
 
-  public execute () {
-    // TODO: verify this is possible!
-    this._entity.moveBy(this._x, this._y)
+  public execute (world: World) {
+    const oldX = this._entity.x
+    const oldY = this._entity.y
+    const newX = oldX + this._x
+    const newY = oldY + this._y
+
+    // check if we can move there
+    if (!world.map.isTraversable(newX, newY)) {
+      return false
+    }
+
+    // remove entity from old cell
+    if (world.map.getCreature(oldX, oldY) === this._entity) {
+      world.map.setCreature(oldX, oldY, undefined)
+    }
+
+    // place creature in new cell
+    world.map.setCreature(newX, newY, this._entity)
+
+    this._entity.moveTo(newX, newY)
     return true
   }
 }

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -1,4 +1,4 @@
-import { compact, find, findIndex, flow, forEach, keys, map, reduce, values } from 'lodash/fp'
+import { compact, find, flow, forEach, keys, map, reduce, values } from 'lodash/fp'
 import { TypedEventEmitter } from 'typed-event-emitter'
 
 import {
@@ -13,7 +13,7 @@ import {
 import { BasicContainer } from './container'
 import { CreatureType } from './creature-db'
 import { CreatureEvents } from './events'
-import { EquipmentSet, EquipmentSlot, Item } from './item'
+import { EquipmentSet, EquipmentSlot, EquipmentSlots, Item } from './item'
 import { ExpeditionMap } from './map'
 import { newId } from './new-id'
 import { Actor, Combatant, Damageable, EventSource, Moveable } from './types'
@@ -126,7 +126,18 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
 
   /** Returns whether or not a specified item is equipped. */
   public isEquipped (item: Item): boolean {
-    return findIndex((equippedItem) => item.id === equippedItem?.id, values(this._equipment)) !== -1
+    return this.getEquippedSlot(item) !== undefined
+  }
+
+  /** Returns the slot this item is equipped in, or undefined if none */
+  public getEquippedSlot (item: Item): EquipmentSlot | undefined {
+    for (const slot of EquipmentSlots) {
+      if (this.equipment[slot] === item) {
+        return slot
+      }
+    }
+
+    return undefined
   }
 
   /**

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -14,7 +14,6 @@ import { BasicContainer } from './container'
 import { CreatureType } from './creature-db'
 import { CreatureEvents } from './events'
 import { EquipmentSet, EquipmentSlot, EquipmentSlots, Item } from './item'
-import { ExpeditionMap } from './map'
 import { newId } from './new-id'
 import { Actor, Combatant, Damageable, EventSource, Moveable } from './types'
 import { World } from './world'
@@ -72,18 +71,12 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
   constructor (
     private _type: CreatureType,
     private _x: number,
-    private _y: number,
-    private _map: ExpeditionMap
+    private _y: number
   ) {
     super()
 
-    if (this._map.getCreature(this._x, this._y) !== undefined) {
-      throw new Error('TODO: do not fail when adding creature to occupied cell')
-    }
-
     this._health = this._type.healthMax
     this.inventory = new Inventory()
-    this._map.setCreature(this._x, this._y, this)
 
     const loot = this._type.lootTable?.collect() ?? []
     forEach((itemTemplate) => {

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -88,8 +88,6 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
     const loot = this._type.lootTable?.collect() ?? []
     forEach((itemTemplate) => {
       this.inventory.addItem(itemTemplate.create())
-      // eslint-disable-next-line no-console
-      console.log(`${this.name} ${this.id} has ${itemTemplate.id}`)
     }, loot)
   }
 

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -288,26 +288,12 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
   }
 
   /**
-   * Moves a creature the specified distance in each axis. If the move is impossible, will return false.
-   * If the move is completed, then true is returned.
+   * Move the creature to the specified location.
    */
-  public moveBy (x: number, y: number) {
-    const newX = this._x + x
-    const newY = this._y + y
-
-    if (!this._map.isTraversable(newX, newY)) {
-      return false
-    }
-
-    if (this._map.getCreature(this._x, this._y) === this) {
-      this._map.setCreature(this._x, this._y, undefined)
-    }
-
-    this._x = newX
-    this._y = newY
-
-    this._map.setCreature(this._x, this._y, this)
-    return true
+  public moveTo (x: number, y: number) {
+    this._x = x
+    this._y = y
+    this.emit('move', x, y, this)
   }
 
   private _getModifiedAttribute (baseValue: number, modifierName: CreatureAttributeModifierMethodName) {

--- a/src/engine/dungeon/dungeon.ts
+++ b/src/engine/dungeon/dungeon.ts
@@ -1,4 +1,4 @@
-import { CreatureTypeId } from 'engine/creature-db'
+import { Creature } from 'engine/creature'
 import { Item } from 'engine/item'
 import { ExpeditionMap } from 'engine/map'
 import { filter, forEach, some } from 'lodash/fp'
@@ -8,11 +8,8 @@ import { Region, RegionTypeName } from './region'
 export class Dungeon {
   /**
    * set of creatures in this dungeon
-   *
-   * TODO: this should be real creature objects, to avoid the post-processing by the World
-   * this is awkward, due to the requirement from Creature to have a map (which we should remove)
    */
-  public readonly creatures: { type: CreatureTypeId; x: number; y: number }[] = []
+  public readonly creatures: Creature[] = []
 
   public readonly treasure: { item: Item; x: number; y: number }[] = []
 

--- a/src/engine/dungeon/spawn-tables.ts
+++ b/src/engine/dungeon/spawn-tables.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { CreatureTypeId } from 'engine/creature-db'
+import { Creature } from 'engine/creature'
+import { CreatureTypeId, CreatureTypes } from 'engine/creature-db'
 import { ProductGroup } from 'engine/spawnable'
 import { find, random } from 'lodash/fp'
 
@@ -7,46 +8,6 @@ import { ItemTemplate, ItemTemplates } from '../item-db'
 
 import { Dungeon } from './dungeon'
 import { Region } from './region'
-
-const armor = ProductGroup.rollOne(
-  [
-    [25, ItemTemplates.leather_armor],
-    [25, ItemTemplates.leather_boots],
-    [25, ItemTemplates.soft_leather_gloves],
-    [25, ItemTemplates.wooden_buckler],
-  ]
-)
-
-const weapons = ProductGroup.rollOne(
-  [
-    [60, ItemTemplates.dagger],
-    [30, ItemTemplates.spear],
-    [10, ItemTemplates.glowing_spear],
-  ]
-)
-
-const jewelry = ProductGroup.rollOne(
-  [
-    [40, ItemTemplates.ring_of_protection],
-    [30, ItemTemplates.gold_circlet],
-    [15, ItemTemplates.necrotic_amulet],
-    [15, ItemTemplates.girdle_of_punching],
-  ]
-)
-
-const armorOrWeapon = ProductGroup.rollOne(
-  [
-    [50, armor],
-    [50, weapons],
-  ]
-)
-
-export const TreasureTable = ProductGroup.rollMany(
-  [
-    [100, armorOrWeapon],
-    [20, jewelry],
-  ]
-)
 
 /** function that adds 'something' to a dungeon */
 type Spawner = (dungeon: Dungeon, room: Region) => void
@@ -73,7 +34,7 @@ const monsterSpawner = (creatureType: CreatureTypeId): Spawner => (dungeon, room
   } while (spaceOccupied(x, y) && loopCount++ < 50)
 
   if (!spaceOccupied(x, y)) {
-    dungeon.creatures.push({ type: creatureType, x, y })
+    dungeon.creatures.push(new Creature(CreatureTypes[creatureType], x, y))
   }
 }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -82,9 +82,9 @@ export interface Positionable extends Entity {
 /** A Moveable entity has a map position, and methods for updating that position. */
 export interface Moveable extends Positionable {
   /**
-   * Moves a creature the specified distance in each axis.
+   * Move an entity to the specified location.
    */
-  moveBy: (x: number, y: number) => void
+  moveTo: (x: number, y: number) => void
 }
 
 /** A Damageable entity has a health pool, and can take damage and 'die'. */

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -32,15 +32,15 @@ export class World extends TypedEventEmitter<WorldEvents> {
 
     const dungeon = createDungeon()
     dungeon.createTerrain(this.map)
-    forEach((spawn) => {
-      this._registerCreature(new Creature(CreatureTypes[spawn.type], spawn.x, spawn.y, this.map))
+    forEach((creature) => {
+      this._registerCreature(creature)
     }, dungeon.creatures)
 
     forEach((treasure) => {
       this.map.getCell(treasure.x, treasure.y).addItem(treasure.item)
     }, dungeon.treasure)
 
-    this._player = new Player(CreatureTypes.player, 0, 0, this.map)
+    this._player = new Player(CreatureTypes.player, 0, 0)
     this._registerCreature(this._player)
     this._playerAction = DoNothing
     // this._player.inventory.addItem(new Item({ name: 'a coconut' }))
@@ -157,9 +157,17 @@ porttitor, imperdiet lectus. Quisque sit amet quam venenatis, iaculis sapien in,
   }
 
   /**
-   * Registers a newly created by creature with the world.
+   * Registers a newly created creature with the world. This includes adding it to the creature list,
+   * adding to the map, and registering any event listeners.
    */
   private _registerCreature (creature: Creature) {
+    if (creature.type.id !== 'player' && this.map.getCreature(creature.x, creature.y) !== undefined) {
+      // if the cell is occupied, skip placing the creature unless it is the player
+      // this represents an error in the dungeon generator...
+      return
+    }
+
+    this.map.setCreature(creature.x, creature.y, creature)
     this.creatures[creature.id] = creature
 
     creature.on('attack', this._logAttack.bind(this))

--- a/src/ui/components/container-contents-panel.css
+++ b/src/ui/components/container-contents-panel.css
@@ -1,0 +1,4 @@
+.inventory-panel-item-description {
+  margin: 4px 0;
+  padding: 0;
+}

--- a/src/ui/components/container-contents-panel.tsx
+++ b/src/ui/components/container-contents-panel.tsx
@@ -27,14 +27,14 @@ export interface ContainerContentsPanelProps extends Omit<ListPanelProps,
 
   /** Called when an item is selected via clicking or the 'enter' key */
   onItemSelected?: (item: Item) => void
+
+  /** Method used to create the 'left' and 'right' content for an item. (default: item name) */
+  toListItem?: (item: Item) => Omit<ListItem, 'id'>
 }
 
-const toListItem = (item: Item): ListItem => {
-  return {
-    id: `${item.id}`,
-    content: item.name,
-  }
-}
+const defaultToListItem = (item: Item) => ({
+  content: item.name,
+})
 
 export const ContainerContentsPanel = ({
   children = <p>There are no items to display.</p>,
@@ -43,9 +43,15 @@ export const ContainerContentsPanel = ({
   onEmpty = noop,
   onItemConsidered = noop,
   onItemSelected = noop,
+  toListItem = defaultToListItem,
   ...listPanelProps
 }: ContainerContentsPanelProps) => {
-  const items = flow(filter(itemFilter), map(toListItem))(container.items)
+  const getListItem = useCallback((item: Item): ListItem => ({
+    id: `${item.id}`,
+    ...toListItem(item),
+  }), [toListItem])
+
+  const items = flow(filter(itemFilter), map(getListItem))(container.items)
 
   useEffect(() => {
     if (items.length === 0) {

--- a/src/ui/components/expedition-ended-screen.tsx
+++ b/src/ui/components/expedition-ended-screen.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useRecoilValue, useResetRecoilState } from 'recoil'
+import { useGlobalKeyHandler } from 'ui/hooks/use-global-key-handler'
 import { useWorld } from 'ui/hooks/use-world'
 import { expeditionState } from 'ui/state/expedition'
 
@@ -36,6 +37,10 @@ export const ExpeditionEndedScreen = ({ navigateTo }: ExpeditionEndedScreenProps
 
   const fate = player.dead ? 'was killed' : 'lost his connection to this world'
 
+  useGlobalKeyHandler({
+    Escape: returnToTitle,
+  })
+
   const expeditionSummary =
     `${player.name} ${fate}.
     
@@ -46,7 +51,6 @@ Turns: ${expedition.turn - 1}`
       className="screen-container"
       onBlur={handleBlur}
       onClick={returnToTitle}
-      onKeyPress={returnToTitle}
       ref={refCallback}
       tabIndex={0}
     >
@@ -59,7 +63,9 @@ Turns: ${expedition.turn - 1}`
           <PreFormattedText>{expeditionSummary}</PreFormattedText>
         </Panel>
       </div>
-      <p className="screen-footer animated-option" style={{ cursor: 'pointer' }}>Press any key to continue </p>
+      <p className="screen-footer animated-option" style={{ cursor: 'pointer' }}>
+        Press &apos;Escape&apos; to continue
+      </p>
     </div>
   )
 }

--- a/src/ui/components/expedition-screen.css
+++ b/src/ui/components/expedition-screen.css
@@ -24,3 +24,7 @@
   padding: 96px;
   width: 800px;
 }
+
+.expedition-panel {
+  margin: 4px 0;
+}

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -294,27 +294,38 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
           active={activePanel === SelectablePanels.Map && !paused}
           centerX={viewportCenter.x}
           centerY={viewportCenter.y}
+          containerClass="expedition-panel"
           onClick={handleActivatePanel(SelectablePanels.Map)}
           onKeyDown={mapKeyHandler}
           onViewportSizeChanged={handleViewportResize}
         />
 
-        <LogPanel world={world} />
+        <LogPanel
+          containerClass="expedition-panel"
+          world={world}
+        />
       </div>
 
       <div className="sidebar">
-        <PlayerStatusPanel />
+        <PlayerStatusPanel
+          containerClass="expedition-panel"
+        />
 
         <InventoryPanel
           active={false}
           allowSelection={false}
           columns={SidebarColumns}
+          containerClass="expedition-panel"
           onClick={handleActivatePanel(SelectablePanels.Information)}
           onInventoryAction={handleInventoryAction}
           showSlot={true}
         />
 
-        <Panel columns={SidebarColumns} rows={8}>
+        <Panel
+          containerClass="expedition-panel"
+          columns={SidebarColumns}
+          rows={8}
+        >
           Lorem ipsum dolor sit amet.
         </Panel>
       </div>

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -26,7 +26,7 @@ import { ScreenMenu } from './screen-menu'
 
 import './expedition-screen.css'
 
-const SidebarColumns = 45
+const SidebarColumns = 35
 
 enum SelectablePanels {
   Map = 0,
@@ -81,6 +81,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
       // close any open modals
       setModalMode(ModalMode.None)
       setModalArgument(undefined)
+      setActivePanel(SelectablePanels.Map)
     } else {
       // pause, with the default pause modal visible
       setModalMode(ModalMode.Pause)

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -270,6 +270,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
             columns={SidebarColumns}
             onClick={handleActivatePanel(SelectablePanels.Information)}
             onInventoryAction={handleInventoryAction}
+            showSlot={false}
           />
         )
     }
@@ -310,6 +311,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
           columns={SidebarColumns}
           onClick={handleActivatePanel(SelectablePanels.Information)}
           onInventoryAction={handleInventoryAction}
+          showSlot={true}
         />
 
         <Panel columns={SidebarColumns} rows={8}>

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -270,7 +270,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
             columns={SidebarColumns}
             onClick={handleActivatePanel(SelectablePanels.Information)}
             onInventoryAction={handleInventoryAction}
-            showSlot={false}
+            showSlot={true}
           />
         )
     }

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -30,9 +30,9 @@ const SidebarColumns = 45
 
 enum SelectablePanels {
   Map = 0,
-  Information,
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __LENGTH,
+  Information,
   Options,
 }
 
@@ -40,7 +40,8 @@ enum SelectablePanels {
 enum ModalMode {
   None = 0,
   Pause,
-  InteractWithItem
+  InteractWithItem,
+  Inventory
 }
 
 export interface ExpeditionScreenProps {
@@ -219,8 +220,17 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
     }
   }, [navigateTo])
 
+  const toggleModal = useCallback((modal: ModalMode) => () => {
+    if (modalMode === modal) {
+      setModalMode(ModalMode.None)
+    } else {
+      setModalMode(modal)
+    }
+  }, [modalMode])
+
   useGlobalKeyHandler({
     Escape: handleEscape,
+    [keyMap.OpenInventory]: toggleModal(ModalMode.Inventory),
     Tab: () => setActivePanel((current) => (current + 1) % SelectablePanels.__LENGTH),
   })
 
@@ -249,6 +259,17 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
             interaction={modelArgument ?? 'Get'}
             onNoValidInteractions={handleNoMoreItemInteractions}
             onInteraction={interactWithItem}
+          />
+        )
+
+      case ModalMode.Inventory:
+        return (
+          <InventoryPanel
+            active={true}
+            allowSelection={true}
+            columns={SidebarColumns}
+            onClick={handleActivatePanel(SelectablePanels.Information)}
+            onInventoryAction={handleInventoryAction}
           />
         )
     }
@@ -284,8 +305,8 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
         <PlayerStatusPanel />
 
         <InventoryPanel
-          active={activePanel === SelectablePanels.Information && !paused}
-          allowSelection={true}
+          active={false}
+          allowSelection={false}
           columns={SidebarColumns}
           onClick={handleActivatePanel(SelectablePanels.Information)}
           onInventoryAction={handleInventoryAction}

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -11,6 +11,7 @@ import { useResetRecoilState, useSetRecoilState } from 'recoil'
 import { useGlobalKeyHandler } from 'ui/hooks/use-global-key-handler'
 import { useKeyHandler } from 'ui/hooks/use-key-handler'
 import { useWorld } from 'ui/hooks/use-world'
+import { getKeyMap } from 'ui/key-map'
 import { endTurn, expeditionState } from 'ui/state/expedition'
 
 import { ScreenName } from './app'
@@ -41,33 +42,6 @@ enum ModalMode {
   Pause,
   InteractWithItem
 }
-
-interface KeyMap {
-  Get: string
-  MoveUp: string
-  MoveDown: string
-  MoveLeft: string
-  MoveRight: string
-}
-
-const KeyMaps = {
-  Sean: {
-    Get: 'g',
-    MoveUp: 'e',
-    MoveDown: 'd',
-    MoveLeft: 's',
-    MoveRight: 'f',
-  },
-  EveryoneElse: {
-    Get: 'g',
-    MoveUp: 'w',
-    MoveDown: 's',
-    MoveLeft: 'a',
-    MoveRight: 'd',
-  },
-}
-
-const keyMap: KeyMap = KeyMaps.Sean
 
 export interface ExpeditionScreenProps {
   /** function that allows inter-screen navigation */
@@ -224,6 +198,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
     setActivePanel(SelectablePanels.Map)
   }, [executeTurn, world])
 
+  const keyMap = getKeyMap()
   const mapKeyHandler = useKeyHandler({
     [keyMap.Get]: beginItemInteraction('Get'),
     [keyMap.MoveDown]: executePlayerMove(0, 1),

--- a/src/ui/components/inventory-panel.tsx
+++ b/src/ui/components/inventory-panel.tsx
@@ -1,6 +1,6 @@
 import { Item } from 'engine/item'
 import { ItemInventoryAction } from 'engine/item-inventory-action'
-import { get, head, map, noop } from 'lodash/fp'
+import { get, map, noop } from 'lodash/fp'
 import { useCallback, useEffect, useState } from 'react'
 import { useWorld } from 'ui/hooks/use-world'
 
@@ -22,7 +22,7 @@ export const InventoryPanel = ({
   ...rest
 }: InventoryPanelProps) => {
   const creature = useWorld().player
-  const [selectedItem, setSelectedItem] = useState(head(creature.inventory.items))
+  const [selectedItem, setSelectedItem] = useState<Item | undefined>()
 
   // if the user tabs out of the list, clear the item selection to avoid confusion
   useEffect(() => {
@@ -33,10 +33,16 @@ export const InventoryPanel = ({
 
   const handleItemAction = useCallback((name: string) => {
     if (selectedItem !== undefined) {
-      const action = selectedItem.getInventoryAction(name)
-      if (action !== undefined) {
-        onInventoryAction(selectedItem, action)
+      if (name === 'Back') {
+        // just go back to inventory screen
         setSelectedItem(undefined)
+      } else {
+        // real item action, let's invoke it
+        const action = selectedItem.getInventoryAction(name)
+        if (action !== undefined) {
+          onInventoryAction(selectedItem, action)
+          setSelectedItem(undefined)
+        }
       }
     }
   }, [onInventoryAction, selectedItem])

--- a/src/ui/components/inventory-panel.tsx
+++ b/src/ui/components/inventory-panel.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useWorld } from 'ui/hooks/use-world'
 
 import { ContainerContentsPanel } from './container-contents-panel'
-import { ListPanel, ListPanelProps } from './list-panel'
+import { ListItem, ListPanel, ListPanelProps } from './list-panel'
 
 import './inventory-panel.css'
 
@@ -14,11 +14,15 @@ ListPanelProps, 'items' | 'title' | 'container' | 'onItemConsidered' | 'onItemSe
 > & {
   /** callback invoked when a user attempts to execute an inventory action on an item */
   onInventoryAction?: (item: Item, action: ItemInventoryAction) => void
+
+  /** if true, inventory items will show what slot they are equipped/held in */
+  showSlot?: boolean
 }
 
 export const InventoryPanel = ({
   active,
   onInventoryAction = noop,
+  showSlot = false,
   ...rest
 }: InventoryPanelProps) => {
   const creature = useWorld().player
@@ -30,6 +34,18 @@ export const InventoryPanel = ({
       setSelectedItem(undefined)
     }
   }, [active])
+
+  const toListItem = useCallback((item: Item): ListItem => {
+    const slot = creature.getEquippedSlot(item)
+    const rightContent = slot === undefined ? '' : `[${slot}]`
+
+    return showSlot ? {
+      content: item.name,
+      rightContent,
+    } : {
+      content: item.name,
+    }
+  }, [creature, showSlot])
 
   const handleItemAction = useCallback((name: string) => {
     if (selectedItem !== undefined) {
@@ -53,6 +69,7 @@ export const InventoryPanel = ({
       container={creature.inventory}
       onItemSelected={setSelectedItem}
       title="Inventory"
+      toListItem={toListItem}
     />
   ) : (
     <ListPanel {...rest}

--- a/src/ui/components/list-panel.css
+++ b/src/ui/components/list-panel.css
@@ -23,12 +23,14 @@
 }
 
 .list-panel-row {
-  cursor: pointer;
   display: flex;
   flex-direction: row;
   list-style-type: none;
   margin: 0;
   padding: 0
+}
+.list-panel-row.selectable {
+  cursor: pointer;
 }
 
 .list-panel-row.selectable:before {
@@ -39,7 +41,7 @@
   content: '>\00a0';
 }
 
-.list-panel-row.selected, .list-panel-row:hover {
+.list-panel-row.selected, .list-panel-row.selectable:hover {
   color: #aa0;
 }
 

--- a/src/ui/components/list-panel.css
+++ b/src/ui/components/list-panel.css
@@ -5,9 +5,16 @@
   padding: 0;
 }
 
+/* child content displayed before the list */
+.list-panel-summary {
+  border-top: solid 1px #550;
+  color: #abd;
+  margin: 12px 0 0 0;
+  padding: 4px 0 0 0;
+}
+
 .list-panel-title {
-  background-color: #222;
-  border: 1px solid #333;
+  background-color: #111;
   font-size: 1em;
   margin: 0 0 6px 0;
   padding: 2px;

--- a/src/ui/components/list-panel.tsx
+++ b/src/ui/components/list-panel.tsx
@@ -130,10 +130,13 @@ export const ListPanel = ({
       onKeyDown={handleKeyDown}
     >
       {title && <h2 className="list-panel-title">{title}</h2>}
-      {children}
       <ul className="list-panel">
         {mapS(items, createRow)}
       </ul>
+      {children &&
+      <div className="list-panel-summary">
+        {children}
+      </div>}
     </Panel>
   )
 }

--- a/src/ui/components/list-panel.tsx
+++ b/src/ui/components/list-panel.tsx
@@ -86,9 +86,11 @@ export const ListPanel = ({
   }, [items, onItemSelected])
 
   const handleClick = useCallback((index: number) => () => {
-    consider(index)
-    confirmSelection(index)
-  }, [confirmSelection, consider])
+    if (allowSelection) {
+      consider(index)
+      confirmSelection(index)
+    }
+  }, [allowSelection, confirmSelection, consider])
 
   const handleConfirmKey = useCallback(() => {
     confirmSelection(selectedIndex)

--- a/src/ui/components/list-panel.tsx
+++ b/src/ui/components/list-panel.tsx
@@ -20,7 +20,7 @@ export interface ListItem {
 }
 
 // extracts the id from a list item
-const getId = (item: string | ListItem) => isString(item) ? item : item.id ?? item.content
+const getId = (item: string | ListItem) => isString(item) ? item : item?.id ?? item.content
 
 // extracts the left-side content from a list item
 const getLeftContent = (item: string | ListItem) => isString(item) ? item : item.content

--- a/src/ui/components/list-panel.tsx
+++ b/src/ui/components/list-panel.tsx
@@ -2,6 +2,7 @@ import { map as mapS } from 'lodash'
 import { compact, flow, isString, join, noop } from 'lodash/fp'
 import { useCallback, useState } from 'react'
 import { useKeyHandler } from 'ui/hooks/use-key-handler'
+import { getKeyMap } from 'ui/key-map'
 
 import { Panel, PanelProps } from './panel'
 
@@ -89,14 +90,15 @@ export const ListPanel = ({
     confirmSelection(index)
   }, [confirmSelection, consider])
 
-  const handleEnterKey = useCallback(() => {
+  const handleConfirmKey = useCallback(() => {
     confirmSelection(selectedIndex)
   }, [confirmSelection, selectedIndex])
 
+  const keyMap = getKeyMap()
   const handleKeyDown = useKeyHandler({
-    ArrowUp: moveSelectionUp,
-    ArrowDown: moveSelectionDown,
-    Enter: handleEnterKey,
+    [keyMap.MoveUp]: moveSelectionUp,
+    [keyMap.MoveDown]: moveSelectionDown,
+    [keyMap.Confirm]: handleConfirmKey,
   })
 
   const createRow = (item: string | ListItem, index: number) => {

--- a/src/ui/components/log-panel.tsx
+++ b/src/ui/components/log-panel.tsx
@@ -2,11 +2,11 @@ import { World } from 'engine/world'
 import { map, reverse } from 'lodash/fp'
 import { useCallback, useEffect, useState } from 'react'
 
-import { Panel } from './panel'
+import { Panel, PanelProps } from './panel'
 
 import './log-panel.css'
 
-export interface LogPanelOptions {
+export interface LogPanelOptions extends Omit<PanelProps, 'rows'> {
   /** number of log rows to display */
   rows?: number
 
@@ -14,7 +14,7 @@ export interface LogPanelOptions {
   world: World
 }
 
-export const LogPanel = ({ rows = 8, world }: LogPanelOptions) => {
+export const LogPanel = ({ rows = 8, world, ...rest }: LogPanelOptions) => {
   const [lines, setLines] = useState<string[]>(world.messages)
 
   const messageAdded = useCallback(() => {
@@ -31,7 +31,10 @@ export const LogPanel = ({ rows = 8, world }: LogPanelOptions) => {
   let index = 0
 
   return (
-    <Panel className="log-panel" rows={rows}>
+    <Panel {...rest}
+      className="log-panel"
+      rows={rows}
+    >
       {map((line) => <div key={index++}>{line}</div>, reverse(lines))}
     </Panel>
   )

--- a/src/ui/components/modal.css
+++ b/src/ui/components/modal.css
@@ -2,6 +2,7 @@
   background-color: black;
   display: flex;
   left: 50%;
+  max-height: 70%;
   max-width: 50%;
   position: absolute;
   top: 50%;

--- a/src/ui/components/panel.css
+++ b/src/ui/components/panel.css
@@ -3,7 +3,6 @@
   display: flex;
   align-content: stretch;
   flex: 0;
-  margin: 8px 0;
   padding: 1px;
   color: #aaa;
 }
@@ -11,7 +10,7 @@
 
 .container.active {
   border-width: 2px;
-  border-color: #660;
+  border-color: #330;
   padding: 0;
   color: #fff;
 }

--- a/src/ui/components/screen-menu.tsx
+++ b/src/ui/components/screen-menu.tsx
@@ -1,5 +1,6 @@
 import { findIndex, map, noop } from 'lodash/fp'
 import React, { HTMLAttributes, PropsWithChildren, useCallback, useState } from 'react'
+import { getKeyMap } from 'ui/key-map'
 import { toClassName, WithExtraClasses } from 'ui/to-class-name'
 
 import './screen-menu.css'
@@ -57,27 +58,28 @@ export const ScreenMenu = ({
   }, [onSelectionConfirmed])
 
   // navigate the menu via arrow keys
+  const keyMap = getKeyMap()
   const handleKeyPress = useCallback((event: React.KeyboardEvent) => {
     switch (event.key) {
-      case 'ArrowDown': {
+      case keyMap.MoveDown: {
         const index = findIndex((item) => item === selectedItem, items)
         const nextIndex = (index + 1) % items.length
         select(items[nextIndex])
         break
       }
 
-      case 'ArrowUp': {
+      case keyMap.MoveUp: {
         const index = findIndex((item) => item === selectedItem, items)
         const nextIndex = index === 0 ? items.length - 1 : index - 1
         select(items[nextIndex])
         break
       }
 
-      case 'Enter':
+      case keyMap.Confirm:
         confirmSelection(selectedItem)
         break
     }
-  }, [confirmSelection, items, select, selectedItem])
+  }, [confirmSelection, items, keyMap.Confirm, keyMap.MoveDown, keyMap.MoveUp, select, selectedItem])
 
   // navigate the menu via mouse
   const handleHover = useCallback((item: string) => () => {

--- a/src/ui/key-map.ts
+++ b/src/ui/key-map.ts
@@ -5,6 +5,7 @@ export interface KeyMap {
   MoveDown: string
   MoveLeft: string
   MoveRight: string
+  OpenInventory: string
 }
 
 const KeyMaps = {
@@ -15,6 +16,7 @@ const KeyMaps = {
     MoveDown: 'd',
     MoveLeft: 's',
     MoveRight: 'f',
+    OpenInventory: 'b',
   },
   EveryoneElse: {
     Confirm: 'Enter',
@@ -23,6 +25,7 @@ const KeyMaps = {
     MoveDown: 's',
     MoveLeft: 'a',
     MoveRight: 'd',
+    OpenInventory: 'i',
   },
 }
 

--- a/src/ui/key-map.ts
+++ b/src/ui/key-map.ts
@@ -1,0 +1,29 @@
+export interface KeyMap {
+  Confirm: string
+  Get: string
+  MoveUp: string
+  MoveDown: string
+  MoveLeft: string
+  MoveRight: string
+}
+
+const KeyMaps = {
+  Sean: {
+    Confirm: 'Enter',
+    Get: 'g',
+    MoveUp: 'e',
+    MoveDown: 'd',
+    MoveLeft: 's',
+    MoveRight: 'f',
+  },
+  EveryoneElse: {
+    Confirm: 'Enter',
+    Get: 'g',
+    MoveUp: 'w',
+    MoveDown: 's',
+    MoveLeft: 'a',
+    MoveRight: 'd',
+  },
+}
+
+export const getKeyMap = (): KeyMap => KeyMaps.Sean


### PR DESCRIPTION
- Require escape key to configure after dying instead of any key.
- Add supporting for customizing item content in container contents panel.
- Navigate menus with the same keys as the map.
- Move inventory management to modal instead of sidebar.
- Show slot items are equipped in on sidebar.
- Move traversability checks out of creature and into move action.
- Remove map dependency from creatures.
- Print the items in a cell when entering it.
- Update item list visual styles to separate options from description more clearly.
- Add ability to render item description in container contents panel.
- Disable sidebar hover and click events.
