### PR TITLE
feat: add combat flash effect

### DIFF
--- a/src/engine/map/map-symbolizer.ts
+++ b/src/engine/map/map-symbolizer.ts
@@ -1,3 +1,7 @@
+import { Creature } from 'engine/creature'
+import { Item } from 'engine/item'
+import { TerrainType } from 'engine/terrain-db'
+
 import { MapCell } from './map'
 import { MapSymbol } from './map-symbol'
 import { CreatureSymbols, ItemSymbols, TerrainSymbols } from './map-symbol-set'
@@ -15,6 +19,37 @@ export const withDefaultBackground = (cell: MapCell, entitySymbol: MapSymbol) =>
     ...entitySymbol,
     background: TerrainSymbols[cell.terrain.id]?.background ?? TerrainSymbols.default.background,
   }
+}
+
+export const getCreatureSymbol = (creature: Creature): MapSymbol => {
+  const creatureSymbol = CreatureSymbols[creature.type.id]
+  if (creatureSymbol === undefined) {
+    return CreatureSymbols.default
+  }
+
+  return creatureSymbol
+}
+
+export const getItemSymbol = (items: readonly Item[]): MapSymbol => {
+  if (items.length > 1) {
+    return ItemSymbols.multiple
+  } else if (items.length > 0) {
+    return ItemSymbols.default
+  }
+
+  return {
+    color: 0x0,
+    symbol: ' ',
+  }
+}
+
+export const getTerrainSymbol = (terrain: TerrainType): MapSymbol => {
+  const terrainSymbol = TerrainSymbols[terrain.id]
+  if (terrainSymbol !== undefined) {
+    return terrainSymbol
+  }
+
+  return TerrainSymbols.default
 }
 
 /** Gets the symbol for any entity in the map cell, or undefined if none. */

--- a/src/engine/scripts/problem-of-scale.ts
+++ b/src/engine/scripts/problem-of-scale.ts
@@ -4,16 +4,16 @@ export const ProblemOfScale: Script = {
   onObjectiveProgress: (progress, objective, context) => {
     if (objective.id === 'problem_of_scale') {
       if (progress === 1) {
-        context.showSpeech([
-          {
-            message: 'Yes, yes. Just like that.',
-            speaker: 'Wizardo',
-          },
-          {
-            message: 'Well? What are you waiting for? Kill the rest!',
-            speaker: 'Wizardo',
-          },
-        ])
+        // context.showSpeech([
+        //   {
+        //     message: 'Yes, yes. Just like that.',
+        //     speaker: 'Wizardo',
+        //   },
+        //   {
+        //     message: 'Well? What are you waiting for? Kill the rest!',
+        //     speaker: 'Wizardo',
+        //   },
+        // ])
       } else if (objective.complete) {
         context.showSpeech([
           {

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -65,6 +65,10 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
     this.emit('message', message)
   }
 
+  public get creatures (): readonly Creature[] {
+    return this._creatures
+  }
+
   /**
    * Gets the creature with a specified ID. If there is no creature with that ID, will return undefined.
    */

--- a/src/ui/components/map-panel.tsx
+++ b/src/ui/components/map-panel.tsx
@@ -118,10 +118,10 @@ export const MapPanel = ({
     }
   }, [onViewportSizeChanged, viewportSize])
 
-  // update cell contents on every render
+  // update cell contents on every render (when the world changes)
   useEffect(() => {
     if (sceneGraphRef.current && viewportSize !== undefined) {
-      sceneGraphRef.current.update(
+      sceneGraphRef.current.onWorldUpdate(
         world,
         offsetXRef.current,
         offsetYRef.current,
@@ -155,6 +155,12 @@ export const MapPanel = ({
     )
 
     sceneGraphRef.current = new MapSceneGraph(app, CellWidth, CellHeight)
+    app.ticker.add((delta) => {
+      if (sceneGraphRef.current) {
+        sceneGraphRef.current.update(delta)
+      }
+    })
+
     appRef.current = app
   }, [])
 

--- a/src/ui/components/map-scene-graph.ts
+++ b/src/ui/components/map-scene-graph.ts
@@ -148,7 +148,7 @@ export class MapSceneGraph {
 
     const map = world.map
 
-    for (let cellY = xOffset; cellY < yOffset + viewHeight; cellY++) {
+    for (let cellY = yOffset; cellY < yOffset + viewHeight; cellY++) {
       for (let cellX = xOffset; cellX < xOffset + viewWidth; cellX++) {
         if (this._mapCellTiles[cellY] === undefined) {
           this._mapCellTiles[cellY] = []

--- a/src/ui/components/map-scene-graph.ts
+++ b/src/ui/components/map-scene-graph.ts
@@ -1,0 +1,155 @@
+import { Creature } from 'engine/creature'
+import { MapCell } from 'engine/map/map'
+import { MapSymbol } from 'engine/map/map-symbol'
+import { getCreatureSymbol, getItemSymbol, getTerrainSymbol, withDefaultBackground } from 'engine/map/map-symbolizer'
+import { World } from 'engine/world'
+import * as PIXI from 'pixi.js'
+import { FontNames } from 'ui/fonts'
+
+abstract class AbstractTile {
+  protected container: PIXI.Container
+  protected background: PIXI.Graphics
+  protected symbol: PIXI.BitmapText
+
+  constructor (
+    protected cellWidth: number,
+    protected cellHeight: number
+  ) {
+    this.background = new PIXI.Graphics()
+    this.background.beginFill(0xffffff)
+    this.background.drawRect(0, 0, cellWidth, cellHeight)
+
+    this.symbol = new PIXI.BitmapText(' ', { fontName: FontNames.Map })
+    this.symbol.anchor.set(0.5)
+    this.symbol.position.set(cellWidth / 2, cellHeight / 2 - 2)
+
+    this.container = new PIXI.Container()
+    this.container.addChild(this.background)
+    this.container.addChild(this.symbol)
+  }
+
+  protected setMapSymbol (symbol: MapSymbol) {
+    this.symbol.text = symbol.symbol
+    this.symbol.tint = symbol.color
+    this.background.tint = symbol.background ?? 0x0
+  }
+
+  public addTo (container: PIXI.Container) {
+    if (this.container.parent) {
+      this.container.parent.removeChild(this.container)
+    }
+
+    container.addChild(this.container)
+  }
+
+  public setVisible (visible: boolean) {
+    this.container.visible = visible
+  }
+}
+
+class CreatureTile extends AbstractTile {
+  constructor (
+    private _creature: Creature,
+    cellWidth: number,
+    cellHeight: number
+  ) {
+    super(cellWidth, cellHeight)
+    this.update()
+  }
+
+  public update () {
+    this.setMapSymbol(getCreatureSymbol(this._creature))
+    this.container.position.set(this._creature.x * this.cellWidth, this._creature.y * this.cellHeight)
+
+    this.setVisible(!this._creature.dead)
+
+    if (this._creature.dead) {
+      this.symbol.text = '!'
+    }
+  }
+}
+
+class MapCellTile extends AbstractTile {
+  constructor (
+    private _x: number,
+    private _y: number,
+    private _cell: MapCell,
+    cellWidth: number,
+    cellHeight: number
+  ) {
+    super(cellWidth, cellHeight)
+    this.update()
+  }
+
+  public update () {
+    this.container.position.set(this._x * this.cellWidth, this._y * this.cellHeight)
+
+    // hide ourselves if a creature is here, it's rendering takes precendence
+    this.setVisible(this._cell.creature === undefined)
+
+    if (this._cell.items.length > 0) {
+      this.setMapSymbol(withDefaultBackground(this._cell, getItemSymbol(this._cell.items)))
+    } else {
+      this.setMapSymbol(getTerrainSymbol(this._cell.terrain))
+    }
+  }
+}
+
+export class MapSceneGraph {
+  private _root: PIXI.Container
+  private _creatureTiles: CreatureTile[] = []
+  private _mapCellTiles: MapCellTile[][] = []
+
+  constructor (
+    app: PIXI.Application,
+    private _cellWidth: number,
+    private _cellHeight: number
+  ) {
+    this._root = new PIXI.Container()
+    app.stage.addChild(this._root)
+  }
+
+  public setOffset (cellX: number, cellY: number) {
+    this._root.setTransform(-cellX * this._cellWidth, -cellY * this._cellHeight)
+  }
+
+  /**
+   * Update all creature tiles, and map cell tiles inside the specified rectangle
+   */
+  public update (world: World, xOffset: number, yOffset: number, viewWidth: number, viewHeight: number) {
+    this.setOffset(xOffset, yOffset)
+
+    const map = world.map
+
+    for (let cellY = xOffset; cellY < yOffset + viewHeight; cellY++) {
+      for (let cellX = xOffset; cellX < xOffset + viewWidth; cellX++) {
+        if (this._mapCellTiles[cellY] === undefined) {
+          this._mapCellTiles[cellY] = []
+        }
+
+        if (this._mapCellTiles[cellY][cellX] === undefined) {
+          const cell = map.getCell(cellX, cellY)
+          this._mapCellTiles[cellY][cellX] = new MapCellTile(cellX, cellY, cell, this._cellWidth, this._cellHeight)
+          this._mapCellTiles[cellY][cellX].addTo(this._root)
+        } else {
+          this._mapCellTiles[cellY][cellX].update()
+        }
+      }
+    }
+
+    // create any missing tiles
+    for (const creature of world.creatures) {
+      if (this._creatureTiles[creature.id] === undefined) {
+        this._creatureTiles[creature.id] = new CreatureTile(creature, this._cellWidth, this._cellHeight)
+        this._creatureTiles[creature.id].addTo(this._root)
+      }
+    }
+
+    // update the creature tiles
+    for (const tile of this._creatureTiles) {
+      if (tile) {
+        tile.update()
+      }
+    }
+  }
+}

--- a/src/ui/visual-effects/highlights.ts
+++ b/src/ui/visual-effects/highlights.ts
@@ -93,16 +93,18 @@ export class FlashHighlight extends AbstractHighlight {
 export const missed = () => new FlashHighlight(
   {
     background: 0xffffff,
+    color: 0x333333,
     symbol: ' ',
   },
-  200,
   100,
-  100
+  100,
+  0
 )
 
 export const damaged = () => new FlashHighlight(
   {
     background: 0xff0000,
+    symbol: ' ',
   },
   300,
   50,

--- a/src/ui/visual-effects/highlights.ts
+++ b/src/ui/visual-effects/highlights.ts
@@ -1,0 +1,110 @@
+import { MapSymbol } from 'engine/map/map-symbol'
+
+/**
+ * effect to highlight an entity. called with frames since last update and should return the
+ * symbol to use for highlighting or null if the effect is complete and should be removed
+ */
+export type HighlightEffect = {
+  /** if true, the effect is complete */
+  complete: boolean
+
+  /** gets the duration of this effect, in ms */
+  duration: number
+
+  getSymbol: (defaultSymbol: MapSymbol) => MapSymbol
+}
+
+abstract class AbstractHighlight implements HighlightEffect {
+  private _remainingTime: number
+  private _lastTime: number
+
+  constructor (public duration: number) {
+    this._remainingTime = duration
+    this._lastTime = Date.now()
+  }
+
+  public get complete () {
+    return this._remainingTime <= 0
+  }
+
+  public getSymbol (defaultSymbol: MapSymbol) {
+    const now = Date.now()
+    const elapsed = now - this._lastTime
+    this._remainingTime = this._remainingTime - elapsed
+    this._lastTime = now
+    return {
+      ...defaultSymbol,
+      ...this.getOverride(elapsed),
+    }
+  }
+
+  protected abstract getOverride (elapsed: number): Partial<MapSymbol>
+}
+
+export class NewSymbolHighlight extends AbstractHighlight {
+  constructor (
+    private _symbol: Partial<MapSymbol>,
+    durationInMs: number
+  ) {
+    super(durationInMs)
+  }
+
+  protected getOverride () {
+    return this._symbol
+  }
+}
+
+export class FlashHighlight extends AbstractHighlight {
+  private _defaultIntervalInMs: number
+
+  /** whether we are showing the 'override' or 'default' symbol */
+  private _inOverride = true
+
+  /** the number of frames we have been in this state */
+  private _since = 0
+
+  constructor (
+    private _override: Partial<MapSymbol>,
+    _durationInMs: number,
+    private _overrideIntervalInMs: number,
+    defaultIntervalInMs?: number
+  ) {
+    super(_durationInMs)
+
+    this._defaultIntervalInMs = defaultIntervalInMs ?? this._overrideIntervalInMs
+  }
+
+  protected getOverride (elapsed: number) {
+    this._since = this._since + elapsed
+
+    const maxTime = this._inOverride
+      ? this._overrideIntervalInMs
+      : this._defaultIntervalInMs
+
+    if (this._since > maxTime) {
+      this._since -= maxTime
+      this._inOverride = !this._inOverride
+    }
+
+    return this._inOverride ? this._override : {}
+  }
+}
+
+export const missed = () => new FlashHighlight(
+  {
+    background: 0xffffff,
+    symbol: ' ',
+  },
+  200,
+  100,
+  100
+)
+
+export const damaged = () => new FlashHighlight(
+  {
+    background: 0xff0000,
+  },
+  300,
+  50,
+  100
+)


### PR DESCRIPTION
- Simplify PIXI rendering to allow attaching effects to specific creatures or items.
- Add ability to pause the world.
- Add 'miss' and 'damaged' combat effects.
- Remove initial 'problem of scale' quest dialog.
- Fix bug causing map to be cut off at top.
