### PR TITLE
feat: add Dart Lizard creature

### DIFF
--- a/src/engine/behaviors/startle.ts
+++ b/src/engine/behaviors/startle.ts
@@ -1,0 +1,58 @@
+import { MoveToAction } from 'engine/actions/move-to'
+import { CellCoordinate, MapCell } from 'engine/map/map'
+import { random } from 'engine/random'
+import { getStartledBy } from 'engine/scripts/startle-sensor'
+import { Behavior } from 'engine/types'
+import { sortBy, takeRight } from 'lodash/fp'
+
+/**
+ * The 'startle' behavior causes a creature to run if it is startled.
+ */
+export const startle = (): Behavior => {
+  // if we are startled, our flight path and index along it
+  let flightPath: CellCoordinate[] | undefined
+  let pathIndex = 0
+
+  return (creature, world) => {
+    const startledBy = getStartledBy(creature)
+
+    // if we have been startled, but have no destination, find one!
+    if (startledBy !== undefined && flightPath === undefined) {
+      const traversable = (cell: MapCell) => cell.terrain.traversable
+
+      // get all cells that are further away from what scared us, and traversable
+      const candidateCells = world.map.getCells(traversable, {
+        left: creature.x - 5,
+        top: creature.y - 5,
+        right: creature.x + 5,
+        bottom: creature.y + 5,
+      })
+
+      // pick one of the farther cells at random, and build a path towards it
+      // but ensure the path does not bring us closer to the startling creatyre
+      if (candidateCells.length > 0) {
+        const sortedByDistance = sortBy((cell) => world.map.getPath(startledBy, cell).length, candidateCells)
+
+        // randomly pick a destination from the best 1/3 of options
+        const bestThird = takeRight(sortedByDistance.length / 3, sortedByDistance)
+        const destination = bestThird[random(0, bestThird.length - 1)]
+
+        flightPath = world.map.getPath(creature, destination)
+        pathIndex = 0
+      }
+    }
+
+    // if we have a destination, we are startled... run towards it
+    if (flightPath !== undefined && flightPath.length > 0) {
+      const nextCell = flightPath[pathIndex++]
+      if (pathIndex >= flightPath.length) {
+        flightPath = undefined
+      }
+
+      return new MoveToAction(creature, nextCell.x, nextCell.y)
+    }
+
+    // we aren't startled, so let some other behavior take over
+    return undefined
+  }
+}

--- a/src/engine/behaviors/wander-between-rooms.ts
+++ b/src/engine/behaviors/wander-between-rooms.ts
@@ -15,7 +15,7 @@ const getDestination = (): DestinationFunction => {
   let destinationCell: CellCoordinate | undefined
 
   return (creature: Creature, world: World, unreachable: boolean) => {
-    const rooms = world.dungeon.rooms
+    const rooms = world.dungeon?.rooms ?? []
     if (rooms.length < 1) {
       return undefined
     }
@@ -28,7 +28,7 @@ const getDestination = (): DestinationFunction => {
     }
 
     if (destinationRoom === undefined) {
-      destinationRoom = sample(world.dungeon.rooms)
+      destinationRoom = sample(rooms)
     }
     assert(destinationRoom !== undefined)
 

--- a/src/engine/campaign.ts
+++ b/src/engine/campaign.ts
@@ -3,7 +3,7 @@ import { createForest } from './dungeon/create-forest'
 import { Dungeon } from './dungeon/dungeon'
 import { Objective } from './objective'
 import { WorldScript } from './script-api'
-import { ProblemOfScale } from './scripts/problem-of-scale'
+import { dartLizard } from './scripts/dart-lizard'
 
 /**
  * The Campaign represents all game and player state that persists beyond a single expedition.
@@ -44,6 +44,6 @@ export class DemoCampaign extends Campaign {
     this.addObjective(new Objective(Objectives.problem_of_scale))
     this.addObjective(new Objective(Objectives.strange_blue_rock))
 
-    this.addScript(ProblemOfScale)
+    this.addScript(dartLizard)
   }
 }

--- a/src/engine/campaign.ts
+++ b/src/engine/campaign.ts
@@ -1,9 +1,9 @@
 import { Objectives } from './data/objective-db'
-import { createDungeon } from './dungeon/create-dungeon-v1'
-import { Script } from './engine'
+import { createForest } from './dungeon/create-forest'
+import { Dungeon } from './dungeon/dungeon'
 import { Objective } from './objective'
+import { Script } from './script-api'
 import { ProblemOfScale } from './scripts/problem-of-scale'
-import { World } from './world'
 
 /**
  * The Campaign represents all game and player state that persists beyond a single expedition.
@@ -32,9 +32,8 @@ export class Campaign {
     this._scripts.push(script)
   }
 
-  public createNextWorld (): World {
-    const dungeon = createDungeon()
-    return new World(dungeon)
+  public createNextDungeon (): Dungeon {
+    return createForest()
   }
 }
 

--- a/src/engine/campaign.ts
+++ b/src/engine/campaign.ts
@@ -2,7 +2,7 @@ import { Objectives } from './data/objective-db'
 import { createForest } from './dungeon/create-forest'
 import { Dungeon } from './dungeon/dungeon'
 import { Objective } from './objective'
-import { Script } from './script-api'
+import { WorldScript } from './script-api'
 import { ProblemOfScale } from './scripts/problem-of-scale'
 
 /**
@@ -13,7 +13,7 @@ export class Campaign {
   private _objectives: Objective[] = []
 
   /** script's active in this campaign */
-  private _scripts: Script[] = []
+  private _scripts: WorldScript[] = []
 
   /** Retrieves the player's active objectives */
   public get objectives (): readonly Objective[] {
@@ -24,11 +24,11 @@ export class Campaign {
     this._objectives.push(objective)
   }
 
-  public get scripts (): readonly Script[] {
+  public get scripts (): readonly WorldScript[] {
     return this._scripts
   }
 
-  public addScript (script: Script) {
+  public addScript (script: WorldScript) {
     this._scripts.push(script)
   }
 

--- a/src/engine/container.ts
+++ b/src/engine/container.ts
@@ -33,9 +33,18 @@ export class BasicContainer implements Container {
    * Store an item in this container. Returns true if the item was stored successfully,
    * or false if it could not be stored. (Too large, container is full, container is incapable
    * of holding that item, etc.)
+   *
+   * If the item was already in another container, it will be removed from that container as part
+   * of this call.
    **/
   public addItem (item: Item): boolean {
+    if (item.container !== undefined) {
+      item.container.removeItem(item)
+    }
+
     this._contents.push(item)
+    item.container = this
+
     return true
   }
 

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -9,7 +9,7 @@ import { retaliate } from './behaviors/retaliate'
 import { wanderBetweenRooms } from './behaviors/wander-between-rooms'
 import { MonsterLootTables } from './data/loot-tables'
 import { ItemTemplate } from './item-db'
-import { CreatureScriptFactory } from './script-api'
+import { CreatureScript } from './script-api'
 import { dartLizard } from './scripts/dart-lizard'
 import { Generator } from './spawnable'
 
@@ -36,7 +36,7 @@ export type CreatureType = Readonly<{
   name: string
 
   /** the script for this creature type, if any */
-  script?: CreatureScriptFactory
+  script?: CreatureScript
 
   /** rate at which a creature acts; 100 == one move or standard attack per turn */
   speed: number

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -11,7 +11,9 @@ import { MonsterLootTables } from './data/loot-tables'
 import { ItemTemplate } from './item-db'
 import { CreatureScript } from './script-api'
 import { ageSensor } from './scripts/age-sensor'
+import { creaturesInFrontSensor } from './scripts/creature-sensors'
 import { dartLizard } from './scripts/dart-lizard'
+import { facingSensor } from './scripts/facing-sensor'
 import { Generator } from './spawnable'
 
 export type CreatureType = Readonly<{
@@ -56,7 +58,7 @@ const creatureTypeArray = [
     lootTable: MonsterLootTables[1],
     melee: 1,
     name: 'Dart Lizard',
-    scripts: [ageSensor, dartLizard],
+    scripts: [ageSensor, facingSensor, creaturesInFrontSensor(6), dartLizard],
     speed: 100,
   },
   {

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -35,8 +35,8 @@ export type CreatureType = Readonly<{
   /** name of this creature type */
   name: string
 
-  /** the script for this creature type, if any */
-  script?: CreatureScript
+  /** custom scripts for this creature type, if any */
+  scripts?: CreatureScript[]
 
   /** rate at which a creature acts; 100 == one move or standard attack per turn */
   speed: number
@@ -55,7 +55,7 @@ const creatureTypeArray = [
     lootTable: MonsterLootTables[1],
     melee: 1,
     name: 'Dart Lizard',
-    script: dartLizard,
+    scripts: [dartLizard],
     speed: 100,
   },
   {

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -6,14 +6,16 @@ import { BehaviorChain } from './behaviors/behavior-chain'
 import { maybeIdle } from './behaviors/idle'
 import { MoveRandomlyBehavior } from './behaviors/move-randomly'
 import { retaliate } from './behaviors/retaliate'
+import { startle } from './behaviors/startle'
 import { wanderBetweenRooms } from './behaviors/wander-between-rooms'
 import { MonsterLootTables } from './data/loot-tables'
 import { ItemTemplate } from './item-db'
 import { CreatureScript } from './script-api'
 import { ageSensor } from './scripts/age-sensor'
 import { creaturesInFrontSensor } from './scripts/creature-sensors'
-import { dartLizard } from './scripts/dart-lizard'
+import { dartLizard, DefaultDartLizardSpeed } from './scripts/dart-lizard'
 import { facingSensor } from './scripts/facing-sensor'
+import { startleSensor } from './scripts/startle-sensor'
 import { Generator } from './spawnable'
 
 export type CreatureType = Readonly<{
@@ -51,15 +53,21 @@ const wander100Percent = maybeIdle(wanderBetweenRooms(), 0)
 
 const creatureTypeArray = [
   {
-    createBehavior: () => MoveRandomlyBehavior(),
+    createBehavior: () => BehaviorChain(startle(), MoveRandomlyBehavior()),
     defense: 0,
     healthMax: 2,
     id: 'dart_lizard',
     lootTable: MonsterLootTables[1],
     melee: 1,
     name: 'Dart Lizard',
-    scripts: [ageSensor, facingSensor, creaturesInFrontSensor(6), dartLizard],
-    speed: 100,
+    scripts: [
+      ageSensor,
+      facingSensor,
+      creaturesInFrontSensor(6),
+      startleSensor({ turnsToFlee: 10 }),
+      dartLizard,
+    ],
+    speed: DefaultDartLizardSpeed,
   },
   {
     createBehavior: () => BehaviorChain(retaliate, attackPlayer, moveRandom100Percent),

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -9,6 +9,7 @@ import { retaliate } from './behaviors/retaliate'
 import { wanderBetweenRooms } from './behaviors/wander-between-rooms'
 import { MonsterLootTables } from './data/loot-tables'
 import { ItemTemplate } from './item-db'
+import { CreatureScriptFactory } from './script-api'
 import { Generator } from './spawnable'
 
 export type CreatureType = Readonly<{
@@ -32,6 +33,9 @@ export type CreatureType = Readonly<{
 
   /** name of this creature type */
   name: string
+
+  /** the script for this creature type, if any */
+  script?: CreatureScriptFactory
 
   /** rate at which a creature acts; 100 == one move or standard attack per turn */
   speed: number

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -53,7 +53,7 @@ const wander100Percent = maybeIdle(wanderBetweenRooms(), 0)
 
 const creatureTypeArray = [
   {
-    createBehavior: () => BehaviorChain(startle(), MoveRandomlyBehavior()),
+    createBehavior: () => BehaviorChain(startle(), maybeIdle(MoveRandomlyBehavior(), 70)),
     defense: 0,
     healthMax: 2,
     id: 'dart_lizard',

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -10,6 +10,7 @@ import { wanderBetweenRooms } from './behaviors/wander-between-rooms'
 import { MonsterLootTables } from './data/loot-tables'
 import { ItemTemplate } from './item-db'
 import { CreatureScriptFactory } from './script-api'
+import { dartLizard } from './scripts/dart-lizard'
 import { Generator } from './spawnable'
 
 export type CreatureType = Readonly<{
@@ -46,6 +47,17 @@ const moveRandom20Percent = maybeIdle(MoveRandomlyBehavior(), 80)
 const wander100Percent = maybeIdle(wanderBetweenRooms(), 0)
 
 const creatureTypeArray = [
+  {
+    createBehavior: () => MoveRandomlyBehavior(),
+    defense: 0,
+    healthMax: 2,
+    id: 'dart_lizard',
+    lootTable: MonsterLootTables[1],
+    melee: 1,
+    name: 'Dart Lizard',
+    script: dartLizard,
+    speed: 100,
+  },
   {
     createBehavior: () => BehaviorChain(retaliate, attackPlayer, moveRandom100Percent),
     defense: 1,

--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -10,6 +10,7 @@ import { wanderBetweenRooms } from './behaviors/wander-between-rooms'
 import { MonsterLootTables } from './data/loot-tables'
 import { ItemTemplate } from './item-db'
 import { CreatureScript } from './script-api'
+import { ageSensor } from './scripts/age-sensor'
 import { dartLizard } from './scripts/dart-lizard'
 import { Generator } from './spawnable'
 
@@ -55,7 +56,7 @@ const creatureTypeArray = [
     lootTable: MonsterLootTables[1],
     melee: 1,
     name: 'Dart Lizard',
-    scripts: [dartLizard],
+    scripts: [ageSensor, dartLizard],
     speed: 100,
   },
   {

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -15,6 +15,7 @@ import { CreatureType } from './creature-db'
 import { CreatureEvents } from './events'
 import { EquipmentSet, EquipmentSlot, EquipmentSlots, Item } from './item'
 import { newId } from './new-id'
+import { CreatureScript } from './script-api'
 import { createSensors } from './sensors/create-sensors'
 import { Actor, Behavior, Combatant, Damageable, EventSource, Moveable } from './types'
 import { World } from './world'
@@ -73,6 +74,8 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
   /** inventory of items held by this creature */
   public readonly inventory: Inventory
 
+  public readonly script: CreatureScript | undefined
+
   /** sensors that can be used by behaviors */
   public readonly sensors = createSensors(this)
 
@@ -94,6 +97,7 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
     this.inventory = new Inventory()
     this.speed = this._type.speed
     this._behavior = this._type.createBehavior()
+    this.script = this._type.script?.(this)
 
     const loot = this._type.lootTable?.collect() ?? []
     forEach((itemTemplate) => {
@@ -310,9 +314,12 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
    * Move the creature to the specified location.
    */
   public moveTo (x: number, y: number) {
+    const oldX = this._x
+    const oldY = this._y
+
     this._x = x
     this._y = y
-    this.emit('move', x, y, this)
+    this.emit('move', this, x, y, oldX, oldY)
   }
 
   private _getModifiedAttribute (baseValue: number, modifierName: CreatureAttributeModifierMethodName) {

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -122,10 +122,10 @@ export class Creature extends CreatureEventEmitter implements
    * Gets the script property with the given key from the creature. If the optional property is
    * false, an error will be thrown if it does not exist.
    */
-  public getScriptData <T = unknown>(key: string): T;
-  public getScriptData <T = unknown>(key: string, optional?: false): T;
-  public getScriptData <T = unknown>(key: string, optional: true): T | undefined
-  public getScriptData <T = unknown> (key: string, optional = false): T | undefined {
+  public getScriptData <T = unknown>(key: string): Readonly<T>;
+  public getScriptData <T = unknown>(key: string, optional?: false): Readonly<T>;
+  public getScriptData <T = unknown>(key: string, optional: true): Readonly<T> | undefined
+  public getScriptData <T = unknown> (key: string, optional = false): Readonly<T> | undefined {
     const data = this._scriptData[key]
     if (!optional && data === undefined) {
       throw new Error(`Required script data with key '${key}' not found on creature ${this.id} (name=${this.name})`)

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -256,8 +256,8 @@ export class Creature extends CreatureEventEmitter implements
     return this._behavior(this, world)
   }
 
-  public turnEnded (_world: World) {
-    // do nothing by default
+  public onTurnEnd () {
+    this.emit('turnEnd', { creature: this })
   }
 
   /// ////////////////////////////////////////////

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -260,6 +260,10 @@ export class Creature extends CreatureEventEmitter implements
     this.emit('turnEnd', { creature: this })
   }
 
+  public onTurnStart () {
+    this.emit('turnStart', { creature: this })
+  }
+
   /// ////////////////////////////////////////////
   // Combatant (Attacker)
 

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -74,6 +74,7 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
   /** inventory of items held by this creature */
   public readonly inventory: Inventory
 
+  /** custom script for this creature */
   public readonly script: CreatureScript | undefined
 
   /** sensors that can be used by behaviors */
@@ -86,6 +87,9 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected _behavior: Behavior
 
+  /** addiitonal properties that are read/written by scripts */
+  private _scriptData: Record<string, any> = {}
+
   constructor (
     private _type: CreatureType,
     private _x: number,
@@ -97,7 +101,7 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
     this.inventory = new Inventory()
     this.speed = this._type.speed
     this._behavior = this._type.createBehavior()
-    this.script = this._type.script?.(this)
+    this.script = this._type.script
 
     const loot = this._type.lootTable?.collect() ?? []
     forEach((itemTemplate) => {
@@ -111,6 +115,30 @@ export class Creature extends TypedEventEmitter<CreatureEvents> implements
 
   public get behavior (): Behavior {
     return this._behavior
+  }
+
+  /// ////////////////////////////////////////////
+  // Scriptable data
+
+  /**
+   * Gets the script property with the given key from the creature. If the optional property is
+   * false, an error will be thrown if it does not exist.
+   */
+  public getScriptData <T = unknown>(key: string): T;
+  public getScriptData <T = unknown>(key: string, optional?: false): T;
+  public getScriptData <T = unknown>(key: string, optional: true): T | undefined
+  public getScriptData <T = unknown> (key: string, optional = false): T | undefined {
+    const data = this._scriptData[key]
+    if (!optional && data === undefined) {
+      throw new Error(`Required script data with key '${key} not found on creature ${this.id} (name=${this.name})`)
+    }
+
+    return data
+  }
+
+  /** Sets the script property with the specified key to the data value on the creature. */
+  public setScriptData <T = any> (key: string, data: T): void {
+    this._scriptData[key] = data
   }
 
   /// ////////////////////////////////////////////

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -128,7 +128,7 @@ export class Creature extends CreatureEventEmitter implements
   public getScriptData <T = unknown> (key: string, optional = false): T | undefined {
     const data = this._scriptData[key]
     if (!optional && data === undefined) {
-      throw new Error(`Required script data with key '${key} not found on creature ${this.id} (name=${this.name})`)
+      throw new Error(`Required script data with key '${key}' not found on creature ${this.id} (name=${this.name})`)
     }
 
     return data

--- a/src/engine/dungeon/create-forest.ts
+++ b/src/engine/dungeon/create-forest.ts
@@ -1,5 +1,30 @@
+import { Creature } from 'engine/creature'
+import { CreatureTypes } from 'engine/creature-db'
+import { random } from 'engine/random'
+import { times } from 'lodash/fp'
+
 import { StaticDungeon } from './static-dungeon'
 
 export const createForest = () => {
-  return new StaticDungeon('forest')
+  const dungeon = new StaticDungeon('forest')
+
+  const isValidSpawnPoint = (x: number, y: number) => {
+    return dungeon.getCreature(x, y) === undefined && dungeon.getTerrain(x, y)?.traversable
+  }
+
+  times(() => {
+    let attempt = 0
+    let success = false
+    while (!success && attempt++ < 50) {
+      const x = random(dungeon.left, dungeon.right)
+      const y = random(dungeon.top, dungeon.bottom)
+
+      if (isValidSpawnPoint(x, y)) {
+        dungeon.creatures.push(new Creature(CreatureTypes.dart_lizard, x, y))
+        success = true
+      }
+    }
+  }, random(2, 3))
+
+  return dungeon
 }

--- a/src/engine/dungeon/create-forest.ts
+++ b/src/engine/dungeon/create-forest.ts
@@ -1,30 +1,7 @@
-import { Creature } from 'engine/creature'
-import { CreatureTypes } from 'engine/creature-db'
-import { random } from 'engine/random'
-import { times } from 'lodash/fp'
-
 import { StaticDungeon } from './static-dungeon'
 
 export const createForest = () => {
   const dungeon = new StaticDungeon('forest')
-
-  const isValidSpawnPoint = (x: number, y: number) => {
-    return dungeon.getCreature(x, y) === undefined && dungeon.getTerrain(x, y)?.traversable
-  }
-
-  times(() => {
-    let attempt = 0
-    let success = false
-    while (!success && attempt++ < 50) {
-      const x = random(dungeon.left, dungeon.right)
-      const y = random(dungeon.top, dungeon.bottom)
-
-      if (isValidSpawnPoint(x, y)) {
-        dungeon.creatures.push(new Creature(CreatureTypes.dart_lizard, x, y))
-        success = true
-      }
-    }
-  }, random(2, 3))
 
   return dungeon
 }

--- a/src/engine/dungeon/dungeon.ts
+++ b/src/engine/dungeon/dungeon.ts
@@ -68,15 +68,22 @@ export class Dungeon implements DungeonGeography {
 
     this.createTerrain(map)
 
-    forEach((treasure) => {
-      map.getCell(treasure.x, treasure.y).addItem(treasure.item)
-    }, this.treasure)
-
-    forEach((creature) => {
-      map.setCreature(creature.x, creature.y, creature)
-    }, this.creatures)
-
     return map
+  }
+
+  /** Invokes a callback for every creature in this dungeon. */
+  public forEachCreature (callback: (creature: Creature) => void) {
+    forEach(callback, this.creatures)
+  }
+
+  /**
+   * Invokes a callback for every treasure (item) in this dungeon. The callback is invoked with the
+   * item, and the (x, y) coordinates of where it should be placed.
+   */
+  public forEachItem (callback: (item: Item, x: number, y: number) => void) {
+    forEach(({ item, x, y }) => {
+      callback(item, x, y)
+    }, this.treasure)
   }
 
   public createTerrain (map: ExpeditionMap) {

--- a/src/engine/dungeon/static-dungeon.ts
+++ b/src/engine/dungeon/static-dungeon.ts
@@ -1,5 +1,7 @@
 import { getAsset, MapAsset } from 'engine/assets'
+import { Creature } from 'engine/creature'
 import { ExpeditionMap } from 'engine/map/map'
+import { find } from 'lodash/fp'
 
 import { Dungeon } from './dungeon'
 
@@ -13,13 +15,47 @@ export class StaticDungeon extends Dungeon {
     this._map = getAsset(this._mapAssetName)
   }
 
+  public get width () {
+    return this._map.width
+  }
+
+  public get height () {
+    return this._map.height
+  }
+
+  public get left () {
+    return this._map.offsetX
+  }
+
+  public get right () {
+    return this.left + this.width - 1
+  }
+
+  public get top () {
+    return this._map.offsetY
+  }
+
+  public get bottom () {
+    return this.top + this.height - 1
+  }
+
   public getDefaultTerrain () {
     return this._map.defaultTerrain
   }
 
   public createTerrain (map: ExpeditionMap) {
     this._map.scan((x, y, terrain) => {
-      map.setTerrain(this._map.offsetX + x, this._map.offsetY + y, terrain)
+      map.setTerrain(x, y, terrain)
     })
+  }
+
+  /** gets the creature type at the specified coordinate, or undefined if none */
+  public getCreature (x: number, y: number): Creature | undefined {
+    return find((creature) => creature.x === x && creature.y === y, this.creatures)
+  }
+
+  /** gets the terrain type at the specified coordinate of the dungeon */
+  public getTerrain (x: number, y: number) {
+    return this._map.getTerrain(x, y)
   }
 }

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -134,6 +134,7 @@ export class Engine extends TypedEventEmitter<EngineEvents> implements Updateabl
 
   // world event handlers
   private _handleCreatureSpawnBinding = this._handleCreatureSpawn.bind(this)
+  private _handleTurnBinding = this._handleTurn.bind(this)
 
   constructor (
     private _campaign: Campaign
@@ -184,6 +185,7 @@ export class Engine extends TypedEventEmitter<EngineEvents> implements Updateabl
 
     // attach our listeners
     this._world.on('creatureSpawn', this._handleCreatureSpawnBinding)
+    this._world.on('turn', this._handleTurnBinding)
   }
 
   /** the engine never sleeps */
@@ -192,9 +194,7 @@ export class Engine extends TypedEventEmitter<EngineEvents> implements Updateabl
   }
 
   public update () {
-    forEach((script) => {
-      script.onUpdate?.(this._scriptApi)
-    }, this._campaign.scripts)
+    // noop
   }
 
   /** detaches the current world in preparation for a new one */
@@ -206,6 +206,12 @@ export class Engine extends TypedEventEmitter<EngineEvents> implements Updateabl
       // detach our listeners
       this._world.off('creatureSpawn', this._handleCreatureSpawnBinding)
     }
+  }
+
+  private _handleTurn () {
+    forEach((script) => {
+      script.onTurn?.(this._scriptApi)
+    }, this._campaign.scripts)
   }
 
   private _handleCreatureSpawn (creature: Creature) {

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -94,6 +94,7 @@ class GameController implements ScriptApi {
     const creature = this._world.getCreature(id)
     if (creature !== undefined) {
       this._world.removeCreature(creature)
+      this._eventManager.unregisterCreature(creature.id)
     }
   }
 

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -30,6 +30,10 @@ class GameController implements ScriptApi {
     return this._world.creatures
   }
 
+  public get player (): Creature {
+    return this._world.player
+  }
+
   /** Adds a new creature to the world. It will emit any 'on-spawn' type of events. */
   public addCreature (creatureOrType: Creature | CreatureTypeId, x = 0, y = 0): number {
     const creature = creatureOrType instanceof Creature
@@ -84,6 +88,12 @@ class GameController implements ScriptApi {
     }
   }
 
+  public getMapTile (x: number, y: number): MapTile | undefined {
+    return this._world.map.hasCell(x, y)
+      ? this._world.map.getCell(x, y)
+      : undefined
+  }
+
   public addMapItem (item: Item, x: number, y: number): number {
     this._world.addItemToMap(item, x, y)
     return item.id
@@ -111,6 +121,10 @@ class GameController implements ScriptApi {
 
       this._world.removeItem(item)
     }
+  }
+
+  public showMessage (message: string): void {
+    this._engine.world.logMessage(message)
   }
 
   public showSpeech (speech: Speech[]): void {

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -30,6 +30,13 @@ class GameController implements ScriptApi {
     return creature.id
   }
 
+  public getRandomLocation (filter: (tile: MapTile) => boolean = stubTrue): MapTile | undefined {
+    const matchingCells = this._world.map.getCells(filter)
+    return matchingCells.length === 0
+      ? undefined
+      : matchingCells[random(0, matchingCells.length - 1)]
+  }
+
   /** todo: lots of duplication with MoveToAction */
   public moveCreature (id: number, x: number, y: number): void {
     const creature = this._world.getCreature(id)

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -192,6 +192,11 @@ export class Engine extends TypedEventEmitter<EngineEvents> implements Updateabl
   }
 
   private _handleCreatureSpawn (creature: Creature) {
-    creature.script?.onCreate?.(this._scriptApi)
+    creature.script?.onCreate?.(this._scriptApi, creature)
+
+    // manually forwarding all events will get cumbersome, consider automating
+    creature.on('move', (creature, x, y, oldX, oldY) => {
+      creature.script?.onMove?.(this._scriptApi, creature, { x, y, oldX, oldY })
+    })
   }
 }

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -4,6 +4,7 @@ import { GameTimer } from 'engine/game-timer'
 import { ObjectiveTracker } from 'engine/objective-tracker'
 import { Updateable } from 'engine/types'
 import { World } from 'engine/world'
+import { stubTrue } from 'lodash'
 import { forEach } from 'lodash/fp'
 import { TypedEventEmitter } from 'typed-event-emitter'
 
@@ -11,7 +12,8 @@ import { Creature } from './creature'
 import { CreatureTypeId, CreatureTypes } from './creature-db'
 import { Item } from './item'
 import { MapCell } from './map/map'
-import { ScriptApi, Speech } from './script-api'
+import { random } from './random'
+import { MapTile, ScriptApi, Speech } from './script-api'
 
 class GameController implements ScriptApi {
   constructor (
@@ -24,8 +26,16 @@ class GameController implements ScriptApi {
     return this._world
   }
 
-  public addCreature (type: CreatureTypeId, x: number, y: number): number {
-    const creature = new Creature(CreatureTypes[type], x, y)
+  public get creatures (): readonly Creature[] {
+    return this._world.creatures
+  }
+
+  /** Adds a new creature to the world. It will emit any 'on-spawn' type of events. */
+  public addCreature (creatureOrType: Creature | CreatureTypeId, x = 0, y = 0): number {
+    const creature = creatureOrType instanceof Creature
+      ? creatureOrType
+      : new Creature(CreatureTypes[creatureOrType], x, y)
+
     this._world.addCreature(creature)
     return creature.id
   }

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -17,6 +17,11 @@ export interface WorldEvents {
   message: (message: string) => void
 
   /**
+   * Emitted after all creatures have acted in a turn.
+   */
+  turn: () => void
+
+  /**
    * Emitted after the state is updated.
    */
   update: () => void

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -1,12 +1,15 @@
 import { Attack, AttackResult } from './combat'
 import { Creature } from './creature'
-import { Speech } from './engine'
 import { Objective } from './objective'
+import { Speech } from './script-api'
 import { Entity } from './types'
 
 export interface WorldEvents {
   /** Emitted when any creature is killed */
   creatureDeath: (creature: Creature) => void
+
+  /** emitted when any creature is created */
+  creatureSpawn: (creature: Creature) => void
 
   /**
    * Emitted whenever a log message with meaningful content for the player has been generated.
@@ -38,7 +41,7 @@ export interface CreatureEvents {
   defend: (result: Attack, creature: Creature) => void
 
   /** Emitted when a positionable's map location changes. */
-  move: (x: number, y: number, creature: Creature) => void
+  move: (creature: Creature, x: number, y: number, oldX: number, oldY: number) => void
 }
 
 export interface ObjectiveEvents {

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -1,8 +1,6 @@
-import { Attack, AttackResult } from './combat'
 import { Creature } from './creature'
 import { Objective } from './objective'
 import { Speech } from './script-api'
-import { Entity } from './types'
 
 export interface WorldEvents {
   /** Emitted when any creature is killed */
@@ -25,28 +23,6 @@ export interface WorldEvents {
    * Emitted after the state is updated.
    */
   update: () => void
-}
-
-/**
- * Event types emitted by Creature entities.
- *
- * TODO: most of these aren't currently emitted
- */
-export interface CreatureEvents {
-  /** Emitted whenever the creature performs an attack. */
-  attack: (result: AttackResult, creature: Creature) => void
-
-  /** Emitted when a creature is dealt damage. */
-  damaged: (amount: number, source: Entity, creature: Creature) => void
-
-  /** Emitted when a creature is killed */
-  death: (creature: Creature) => void
-
-  /** Emitted whenever the creature generates a defense against an attack. */
-  defend: (result: Attack, creature: Creature) => void
-
-  /** Emitted when a positionable's map location changes. */
-  move: (creature: Creature, x: number, y: number, oldX: number, oldY: number) => void
 }
 
 export interface ObjectiveEvents {

--- a/src/engine/events/creature-events.ts
+++ b/src/engine/events/creature-events.ts
@@ -1,0 +1,90 @@
+import { Attack, AttackResult } from 'engine/combat'
+import { Creature } from 'engine/creature'
+import { Entity } from 'engine/types'
+import { enumerate } from 'enumerate'
+import { TypedEventEmitter } from 'typed-event-emitter'
+
+export type CreatureEvents = {
+  /** Emitted whenever the creature performs an attack. */
+  attack: {
+    /** creature emitting the event */
+    creature: Creature
+
+    /** the result of the attack */
+    attackResult: AttackResult
+  }
+
+  /** Emitted when the creature is created and added to the game. */
+  create: {
+    creature: Creature
+  }
+
+  /** Emitted when a creature is dealt damage. */
+  damaged: {
+    /** creature emitting the event */
+    creature: Creature
+
+    /** amount of damage taken */
+    amount: number
+
+    /** the source which dealt the damage */
+    source: Entity
+  }
+
+  /** Emitted when a creature is killed */
+  death: {
+    /** creature emitting the event */
+    creature: Creature
+  }
+
+  /** Emitted whenever the creature generates a defense against an attack. */
+  defend: {
+    /** creature emitting the event */
+    creature: Creature
+
+    /** attack that was defended against */
+    attack: Attack
+  }
+
+  /** Emitted when a positionable's map location changes. */
+  move: {
+    /** creature emitting the event */
+    creature: Creature
+
+    /** x-coordinate that was moved to */
+    x: number
+
+    /** y-coordinate that was moved to */
+    y: number
+
+    /** old x-coordinate that was moved from */
+    xOld: number
+
+    /** old y-coordinate that was moved from */
+    yOld: number
+  }
+
+  turnEnd: {
+    /** emitted by a creature after each of its turns completes */
+    creature: Creature
+  }
+}
+
+/**
+ * Array of constants that can be used to iterate over all creature events in the CreatureEvents declaration.
+ * The types guarantee this is an exhaustive list.
+ */
+export const CreatureEventNames = enumerate<keyof CreatureEvents>()(
+  'attack',
+  'create',
+  'damaged',
+  'death',
+  'defend',
+  'move',
+  'turnEnd'
+)
+
+/** event emitter type for creatures */
+export class CreatureEventEmitter extends TypedEventEmitter<{
+  [k in keyof CreatureEvents]: (event: CreatureEvents[k]) => void
+}> {}

--- a/src/engine/events/creature-events.ts
+++ b/src/engine/events/creature-events.ts
@@ -68,6 +68,11 @@ export type CreatureEvents = {
     /** emitted by a creature after each of its turns completes */
     creature: Creature
   }
+
+  turnStart: {
+    /** emitted by a creature after each of its turns begins */
+    creature: Creature
+  }
 }
 
 /**
@@ -81,7 +86,8 @@ export const CreatureEventNames = enumerate<keyof CreatureEvents>()(
   'death',
   'defend',
   'move',
-  'turnEnd'
+  'turnEnd',
+  'turnStart'
 )
 
 /** event emitter type for creatures */

--- a/src/engine/events/event-manager.ts
+++ b/src/engine/events/event-manager.ts
@@ -1,0 +1,38 @@
+import { Creature } from 'engine/creature'
+import { TypedEventEmitter } from 'typed-event-emitter'
+
+import { CreatureEventEmitter } from './creature-events'
+
+type ManagedCreature = Omit<Creature, keyof CreatureEventEmitter>
+
+export type EventManagerEvents = {
+  /** Emitted when a new creature is registered with the event manager. */
+  registerCreature: { creature: ManagedCreature; eventEmitter: CreatureEventEmitter }
+
+  /** Emitted when a creature is removed from the event manager. */
+  unregisterCreature: { creatureId: number; eventEmitter: CreatureEventEmitter }
+}
+
+type EventManagerEventTypes = { [k in keyof EventManagerEvents]: (event: EventManagerEvents[k]) => void }
+
+export class EventManager extends TypedEventEmitter<EventManagerEventTypes> {
+  private _creatureEventEmitters: Record<number, CreatureEventEmitter> = {}
+
+  public creature (id: number): CreatureEventEmitter | undefined {
+    return this._creatureEventEmitters[id]
+  }
+
+  /** Registers a CreatureEventEmitter for the given creature */
+  public registerCreature (creature: Creature, eventEmitter: CreatureEventEmitter) {
+    this._creatureEventEmitters[creature.id] = eventEmitter
+    this.emit('registerCreature', { creature, eventEmitter: this._creatureEventEmitters[creature.id] })
+  }
+
+  /** Removes a creature from the event manager */
+  public unregisterCreature (id: number) {
+    if (this._creatureEventEmitters[id] !== undefined) {
+      this.emit('unregisterCreature', { creatureId: id, eventEmitter: this._creatureEventEmitters[id] })
+      delete this._creatureEventEmitters[id]
+    }
+  }
+}

--- a/src/engine/events/types.ts
+++ b/src/engine/events/types.ts
@@ -1,0 +1,2 @@
+/** converts the event name (for use in calls to 'on'), into a handler function name in scripts */
+export type EventHandlerName<T extends string> = `on${Capitalize<T>}`

--- a/src/engine/item.ts
+++ b/src/engine/item.ts
@@ -1,5 +1,6 @@
 import { find, findIndex } from 'lodash/fp'
 
+import { Container } from './container'
 import { CreatureAttributeModifiers } from './creature'
 import { get } from './item-interaction'
 import { drop, equip, unequip } from './item-inventory-action'
@@ -50,14 +51,17 @@ export interface ItemOptions {
 export class Item implements Entity {
   public readonly id = newId()
 
+  /** the container that holds this item, if any */
+  public container: Container | undefined
+
+  /** detailed description */
+  public readonly description: string | undefined
+
   /** the slots in which this item can be equipped, which may be an empty list */
   public readonly equipmentSlots: EquipmentSlot[]
 
   /** the effects of wearing this equipment, which may be undefined */
   public readonly equipmentEffects: EquipmentEffects | undefined
-
-  /** detailed description */
-  public readonly description: string | undefined
 
   /** name of this item */
   public readonly name: string

--- a/src/engine/map/map-symbol-set.ts
+++ b/src/engine/map/map-symbol-set.ts
@@ -11,19 +11,23 @@ const ColorValues = {
     color: 0x990000,
   },
   PassiveCreature: {
-    background: 0x222200,
-    color: 0x999900,
+    color: 0x222200,
+    background: 0x999900,
   },
   White: 0xffffff,
 } as const
 
 /** Map symbols for all creature types. */
 
-export const CreatureSymbols: { [k in CreatureTypeId | 'default']: MapSymbol } = {
+export const CreatureSymbols: { default: MapSymbol } & { [k in CreatureTypeId]?: MapSymbol } = {
   default: {
     background: 0x002200,
     color: 0xffffff,
     symbol: 'z',
+  },
+  dart_lizard: {
+    ...ColorValues.PassiveCreature,
+    symbol: 'L',
   },
   goblin: {
     ...ColorValues.AggressiveCreature,

--- a/src/engine/map/map-utils.ts
+++ b/src/engine/map/map-utils.ts
@@ -1,6 +1,7 @@
 import { Positionable } from 'engine/types'
+import { filter } from 'lodash/fp'
 
-import { CellCoordinate } from './map'
+import { CellCoordinate, ExpeditionMap } from './map'
 
 /** returns an array of all coordinates adjacent to the supplied ones */
 export const getAdjacentCoordinates = ({ x, y }: CellCoordinate) => [
@@ -13,3 +14,12 @@ export const getAdjacentCoordinates = ({ x, y }: CellCoordinate) => [
 export const areAdjacent = (entity1: Positionable, entity2: Positionable) =>
   (entity1.y === entity2.y && Math.abs(entity1.x - entity2.x) < 2) ||
   (entity1.x === entity2.x && Math.abs(entity1.y - entity2.y) < 2)
+
+/**
+ * HoF that uses map data to find traversable neighbors of a given cell. This function is suitable
+ * to use as input to the aStar method's "getNeighbors" option.
+ */
+export const getTraversableNeighbors = (map: ExpeditionMap) => (cell: CellCoordinate) => {
+  const possibilities = getAdjacentCoordinates(cell)
+  return filter(({ x, y }) => map.getTerrain(x, y).traversable, possibilities)
+}

--- a/src/engine/player.ts
+++ b/src/engine/player.ts
@@ -3,7 +3,6 @@ import { Creature } from './creature'
 import { CreatureTypes } from './creature-db'
 import { CellCoordinate } from './map/map'
 import { Action } from './types'
-import { World } from './world'
 
 export const InitialLinkValue = 5000
 
@@ -29,8 +28,8 @@ export class Player extends Creature {
   }
 
   /** Each turn, decrease the link strength */
-  public turnEnded (world: World): void {
-    super.turnEnded(world)
+  public onTurnEnd (): void {
+    super.onTurnEnd()
     this._link--
   }
 }

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -18,45 +18,45 @@ export interface ScriptApi {
    * Adds a creature to the game world at the specified coordinates. The ID of the newly added
    * creature is returned. Will fail if the space is occupied.
    */
-  addCreature: (type: CreatureTypeId, x: number, y: number) => number
+  addCreature (type: CreatureTypeId, x: number, y: number): number
 
   /**
    * Moves the specified creature to the new (x, y) location. Will fail if the new space is occupied
    * or the creature does not exist.
    */
-  moveCreature: (id: number, x: number, y: number) => void
+  moveCreature (id: number, x: number, y: number): void
 
   /**
    * Immediately removes the creature with the specified ID from the world. Will fail silently if there
    * is no creature with that ID.
    */
-  removeCreature: (id: number) => void
+  removeCreature (id: number): void
 
   /**
    * Puts an item in the map cell at the specified coordinates. The ID of the newly added
    * item is returned.
    */
-  addMapItem: (item: Item, x: number, y: number) => number
+  addMapItem (item: Item, x: number, y: number): number
 
   /**
    * Moves the specified item from the map cell currently containing it, to the new location. Will
    * fail if the item does not exist, or is in a container that is NOT a map cell. (i.e. this cannot
    * cause creatures to drop items.)
    */
-  moveMapItem: (id: number, x: number, y: number) => void
+  moveMapItem (id: number, x: number, y: number): void
 
   /**
    * Immediately removes the item with the specified ID from the map. Will fail silently if there
    * is no item with that ID. If the item exists, but is *not* on the ground in a map cell, this call
    * will generate a script error.
    */
-  removeMapItem: (id: number) => void
+  removeMapItem (id: number): void
 
   /**
    * Show the supplied speech content to the user.
    * TODO: determine when it's done, so scripts can do more...
    */
-  showSpeech: (speech: Speech[]) => void
+  showSpeech (speech: Speech[]): void
 }
 
 /**
@@ -64,7 +64,7 @@ export interface ScriptApi {
  * dialog, pan the map to interesting areas, etc. The script interface exposes a number of event
  * handlers that are called by the engine whenever the relevant event occurs.
  */
-export interface Script {
+export interface WorldScript {
   /** called when the script is first loaded into a new world */
   initialize?: (context: ScriptApi) => void
 
@@ -77,10 +77,8 @@ export interface Script {
 /** interface defining the functions that can be implemented by a creature-specific script */
 export interface CreatureScript {
   /** called when a creature is first created and associated with the script */
-  onCreate?: (context: ScriptApi) => void
+  onCreate?: (context: ScriptApi, creature: Creature) => void
 
   /** called when the creature moves */
-  onMove?: (context: ScriptApi, event: { x: number; y: number; oldX: number; oldY: number }) => void
+  onMove?: (context: ScriptApi, creature: Creature, event: { x: number; y: number; oldX: number; oldY: number }) => void
 }
-
-export type CreatureScriptFactory = (creature: Creature) => CreatureScript

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -92,8 +92,11 @@ export interface WorldScript {
 
   onObjectiveProgress?: (progress: number, objective: Objective, context: ScriptApi) => void
 
-  /** called for each game update performed by the main loop */
-  onUpdate?: (api: ScriptApi) => void
+  /**
+   * Called once for each game turn -- that is, after each actor currently active in the game
+   * has had a chance to act.
+   **/
+  onTurn?: (api: ScriptApi) => void
 }
 
 /** interface defining the functions that can be implemented by a creature-specific script */

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -22,7 +22,7 @@ export type MapTile = Readonly<Pick<MapCell,
 'y'
 >>
 
-export interface CreatureApi {
+export type CreatureApi = Readonly<{
   /**
    * Adds a creature to the game world at the specified coordinates. The ID of the newly added
    * creature is returned. Will fail if the space is occupied.
@@ -32,6 +32,9 @@ export interface CreatureApi {
 
   /** Read-only set of all creatures */
   creatures: readonly Creature[]
+
+  /** Retrieves the Creature corresponding to the player. */
+  player: Creature
 
   /**
    * Gets a random tile from the map. If tileFilter is provided, the returned tile will be one for which
@@ -50,10 +53,15 @@ export interface CreatureApi {
   * is no creature with that ID.
   */
   removeCreature (id: number): void
-}
+}>
 
 /** API exposed to scripts attached to creatures, items, etc. */
 export interface ScriptApi extends CreatureApi {
+  /**
+   * Retrieves the map tile at the given coordinates, or undefined if it is outside the existing map.
+   */
+  getMapTile (x: number, y: number): MapTile | undefined
+
   /**
    * Puts an item in the map cell at the specified coordinates. The ID of the newly added
    * item is returned.
@@ -73,6 +81,11 @@ export interface ScriptApi extends CreatureApi {
    * will generate a script error.
    */
   removeMapItem (id: number): void
+
+  /**
+   * Shows the specified message to the user, in the expedition log panel
+   */
+  showMessage (message: string): void
 
   /**
    * Show the supplied speech content to the user.

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -1,5 +1,7 @@
 import { Creature } from './creature'
 import { CreatureTypeId } from './creature-db'
+import { CreatureEvents } from './events/creature-events'
+import { EventHandlerName } from './events/types'
 import { Item } from './item'
 import { MapCell } from './map/map'
 import { Objective } from './objective'
@@ -113,10 +115,6 @@ export interface WorldScript {
 }
 
 /** interface defining the functions that can be implemented by a creature-specific script */
-export interface CreatureScript {
-  /** called when a creature is first created and associated with the script */
-  onCreate?: (context: ScriptApi, creature: Creature) => void
-
-  /** called when the creature moves */
-  onMove?: (context: ScriptApi, creature: Creature, event: { x: number; y: number; oldX: number; oldY: number }) => void
+export type CreatureScript = {
+  readonly [k in keyof CreatureEvents as EventHandlerName<k>]?: (event: CreatureEvents[k], game: ScriptApi) => void
 }

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -1,0 +1,86 @@
+import { Creature } from './creature'
+import { CreatureTypeId } from './creature-db'
+import { Item } from './item'
+import { Objective } from './objective'
+
+/** A single piece of content that should be displayed during a dialog 'cutscene'. */
+export interface Speech {
+  /** the source (i.e. speaker, etc.) of the narration or dialog */
+  speaker: string
+
+  /** the actual message (description, dialog, etc.) */
+  message: string
+}
+
+/** API exposed to scripts attached to creatures, items, etc. */
+export interface ScriptApi {
+  /**
+   * Adds a creature to the game world at the specified coordinates. The ID of the newly added
+   * creature is returned. Will fail if the space is occupied.
+   */
+  addCreature: (type: CreatureTypeId, x: number, y: number) => number
+
+  /**
+   * Moves the specified creature to the new (x, y) location. Will fail if the new space is occupied
+   * or the creature does not exist.
+   */
+  moveCreature: (id: number, x: number, y: number) => void
+
+  /**
+   * Immediately removes the creature with the specified ID from the world. Will fail silently if there
+   * is no creature with that ID.
+   */
+  removeCreature: (id: number) => void
+
+  /**
+   * Puts an item in the map cell at the specified coordinates. The ID of the newly added
+   * item is returned.
+   */
+  addMapItem: (item: Item, x: number, y: number) => number
+
+  /**
+   * Moves the specified item from the map cell currently containing it, to the new location. Will
+   * fail if the item does not exist, or is in a container that is NOT a map cell. (i.e. this cannot
+   * cause creatures to drop items.)
+   */
+  moveMapItem: (id: number, x: number, y: number) => void
+
+  /**
+   * Immediately removes the item with the specified ID from the map. Will fail silently if there
+   * is no item with that ID. If the item exists, but is *not* on the ground in a map cell, this call
+   * will generate a script error.
+   */
+  removeMapItem: (id: number) => void
+
+  /**
+   * Show the supplied speech content to the user.
+   * TODO: determine when it's done, so scripts can do more...
+   */
+  showSpeech: (speech: Speech[]) => void
+}
+
+/**
+ * A script is a piece of automation that can be inserted into the normal game flow, to display
+ * dialog, pan the map to interesting areas, etc. The script interface exposes a number of event
+ * handlers that are called by the engine whenever the relevant event occurs.
+ */
+export interface Script {
+  /** called when the script is first loaded into a new world */
+  initialize?: (context: ScriptApi) => void
+
+  onObjectiveProgress?: (progress: number, objective: Objective, context: ScriptApi) => void
+
+  /** called for each game update performed by the main loop */
+  onUpdate?: (api: ScriptApi) => void
+}
+
+/** interface defining the functions that can be implemented by a creature-specific script */
+export interface CreatureScript {
+  /** called when a creature is first created and associated with the script */
+  onCreate?: (context: ScriptApi) => void
+
+  /** called when the creature moves */
+  onMove?: (context: ScriptApi, event: { x: number; y: number; oldX: number; oldY: number }) => void
+}
+
+export type CreatureScriptFactory = (creature: Creature) => CreatureScript

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -1,6 +1,7 @@
 import { Creature } from './creature'
 import { CreatureTypeId } from './creature-db'
 import { Item } from './item'
+import { MapCell } from './map/map'
 import { Objective } from './objective'
 
 /** A single piece of content that should be displayed during a dialog 'cutscene'. */
@@ -12,26 +13,47 @@ export interface Speech {
   message: string
 }
 
-/** API exposed to scripts attached to creatures, items, etc. */
-export interface ScriptApi {
+export type MapTile = Readonly<Pick<MapCell,
+'creature' |
+'containsItem' |
+'items' |
+'terrain'|
+'x' |
+'y'
+>>
+
+export interface CreatureApi {
   /**
    * Adds a creature to the game world at the specified coordinates. The ID of the newly added
    * creature is returned. Will fail if the space is occupied.
    */
   addCreature (type: CreatureTypeId, x: number, y: number): number
+  addCreature (creature: Creature): number
+
+  /** Read-only set of all creatures */
+  creatures: readonly Creature[]
 
   /**
-   * Moves the specified creature to the new (x, y) location. Will fail if the new space is occupied
-   * or the creature does not exist.
+   * Gets a random tile from the map. If tileFilter is provided, the returned tile will be one for which
+   * the filter function returns true. Returns the map tile for the location that was found.
    */
+  getRandomLocation (tileFilter?: (tile: MapTile) => boolean): MapTile | undefined
+
+  /**
+  * Moves the specified creature to the new (x, y) location. Will fail if the new space is occupied
+  * or the creature does not exist.
+  */
   moveCreature (id: number, x: number, y: number): void
 
   /**
-   * Immediately removes the creature with the specified ID from the world. Will fail silently if there
-   * is no creature with that ID.
-   */
+  * Immediately removes the creature with the specified ID from the world. Will fail silently if there
+  * is no creature with that ID.
+  */
   removeCreature (id: number): void
+}
 
+/** API exposed to scripts attached to creatures, items, etc. */
+export interface ScriptApi extends CreatureApi {
   /**
    * Puts an item in the map cell at the specified coordinates. The ID of the newly added
    * item is returned.

--- a/src/engine/scripts/age-sensor.ts
+++ b/src/engine/scripts/age-sensor.ts
@@ -1,0 +1,17 @@
+import { Creature } from 'engine/creature'
+import { CreatureScript } from 'engine/script-api'
+
+const ValueKey = 'sensor.age'
+
+/** Uses the age sensor to get the number of turns a creature has been alive. */
+export const getAge = (creature: Creature) => creature.getScriptData<number>(ValueKey, false)
+
+/** Sensor that determines how long a creature has been alive. */
+export const ageSensor: CreatureScript = {
+  onCreate: ({ creature }) => {
+    creature.setScriptData(ValueKey, 0)
+  },
+  onTurnEnd: ({ creature }) => {
+    creature.setScriptData(ValueKey, (creature.getScriptData<number>(ValueKey, true) ?? 0) + 1)
+  },
+}

--- a/src/engine/scripts/creature-sensors.ts
+++ b/src/engine/scripts/creature-sensors.ts
@@ -31,7 +31,6 @@ export const allCreaturesSensor: CreatureScript = {
 export const creaturesInFrontSensor = (distance: number): CreatureScript => ({
   ...initialize,
   onTurnStart: ({ creature }, api) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const facing = getFacing(creature)
 
     const getTilesFromHorizontalEdge = (distance: number, xDirection: -1 | 0 | 1): MapTile[] => {

--- a/src/engine/scripts/creature-sensors.ts
+++ b/src/engine/scripts/creature-sensors.ts
@@ -1,0 +1,93 @@
+import { Creature } from 'engine/creature'
+import { CreatureScript, MapTile } from 'engine/script-api'
+import { compact, filter, map } from 'lodash/fp'
+
+import { getFacing } from './facing-sensor'
+
+const KEY = 'sensor.creatures'
+
+/** Uses the sensors of the specified creature to get a list of all other creatures it is aware of. */
+export const getDetectedCreatures = (creature: Creature) => creature.getScriptData<Creature[]>(KEY, false)
+
+const initialize: CreatureScript = {
+  onCreate: ({ creature }) => {
+    creature.setScriptData(KEY, [])
+  },
+}
+
+/** 'Sensor' script that detects the presence of all other creatures in the game. */
+export const allCreaturesSensor: CreatureScript = {
+  ...initialize,
+  onTurnStart: ({ creature }, api) => {
+    // filter ourself out of the detected creature list
+    creature.setScriptData(KEY, filter((other) => other.id !== creature.id, api.creatures))
+  },
+}
+
+/**
+ * Sensor script that detects the presence of all creatures in front of this one, within the specified distance.
+ * This sensor does not account for line of sight obstructions, invisible creatures, etc.
+ */
+export const creaturesInFrontSensor = (distance: number): CreatureScript => ({
+  ...initialize,
+  onTurnStart: ({ creature }, api) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const facing = getFacing(creature)
+
+    const getTilesFromHorizontalEdge = (distance: number, xDirection: -1 | 0 | 1): MapTile[] => {
+      const result: MapTile[] = []
+
+      for (let d = 1; d <= distance; d++) {
+        const x = creature.x + (xDirection * d)
+        for (let yOffset = -d; yOffset <= d; yOffset++) {
+          const tile = api.getMapTile(x, creature.y + yOffset)
+          if (tile !== undefined) {
+            result.push(tile)
+          }
+        }
+      }
+
+      return result
+    }
+
+    const getTilesFromVerticalEdge = (distance: number, yDirection: -1 | 0 | 1): MapTile[] => {
+      const result: MapTile[] = []
+
+      for (let d = 1; d <= distance; d++) {
+        const y = creature.y + (yDirection * d)
+        for (let xOffset = -d; xOffset <= d; xOffset++) {
+          const tile = api.getMapTile(creature.x + xOffset, y)
+          if (tile !== undefined) {
+            result.push(tile)
+          }
+        }
+      }
+
+      return result
+    }
+
+    const getTilesInView = () => {
+      // these treats diagonal directions as if they were horizontal
+      // it's fine for now, since we only support 4-axis movement
+      switch (facing) {
+        case 'left':
+        case 'up-left':
+        case 'down-left':
+          return getTilesFromHorizontalEdge(distance, -1)
+        case 'right':
+        case 'up-right':
+        case 'down-right':
+          return getTilesFromHorizontalEdge(distance, 1)
+        case 'up':
+          return getTilesFromVerticalEdge(distance, -1)
+        case 'down':
+          return getTilesFromVerticalEdge(distance, 1)
+      }
+
+      return []
+    }
+
+    const tiles = getTilesInView()
+    creature.setScriptData(KEY, compact(map((tile) => tile.creature, tiles)))
+  },
+})

--- a/src/engine/scripts/dart-lizard.ts
+++ b/src/engine/scripts/dart-lizard.ts
@@ -5,10 +5,14 @@ import { CreatureScript, ScriptApi, WorldScript } from 'engine/script-api'
 import { countBy, get, some } from 'lodash/fp'
 import { distance } from 'math'
 
+import { getAge } from './age-sensor'
+
 type Direction = 'up-left' | 'up' | 'up-right' | 'left' | 'right' | 'down-left' | 'down' | 'down-right' | 'none'
 
 const DisappearChance = 10
 const SpawnChance = 3
+// minimum number of turns a lizard must stay on the map before darting away
+const MinimumAgeBeforeDisappearing = 7
 
 const DefaultMinPromiximityToPlayer = 5
 const DefaultMaxPromiximityToPlayer = 13
@@ -144,9 +148,9 @@ export const dartLizard: CreatureScript & WorldScript = {
     }
   },
   onTurnEnd: ({ creature }, api) => {
-    // each turn a lizard is near heavy brush, there is a chance they dash into it
-    if (nextToHeavyBrush(api, creature.x, creature.y)) {
-      if (random(0, 99) < DisappearChance) {
+    // after a few turns, each turn a lizard is near heavy brush, there is a chance they dash into it
+    if (getAge(creature) > MinimumAgeBeforeDisappearing && random(0, 99) < DisappearChance) {
+      if (nextToHeavyBrush(api, creature.x, creature.y)) {
         api.showMessage('A dart lizard dashes into the brush!')
         api.removeCreature(creature.id)
 

--- a/src/engine/scripts/dart-lizard.ts
+++ b/src/engine/scripts/dart-lizard.ts
@@ -1,0 +1,88 @@
+import { CreatureEvents } from 'engine/events'
+import { Item } from 'engine/item'
+import { CreatureScriptFactory, ScriptApi } from 'engine/script-api'
+
+type Direction = 'up-left' | 'up' | 'up-right' | 'left' | 'right' | 'down-left' | 'down' | 'down-right' | 'none'
+
+const getDirectionOfMovement = (newX: number, newY: number, oldX: number, oldY: number): Direction => {
+  if (newX < oldX) {
+    if (newY < oldY) {
+      return 'up-left'
+    } else if (newY === oldY) {
+      return 'left'
+    } else {
+      return 'down-left'
+    }
+  } else if (newX === oldX) {
+    if (newY < oldY) {
+      return 'up'
+    } else if (newY > oldY) {
+      return 'down'
+    }
+  } else if (newX > oldX) {
+    if (newY < oldY) {
+      return 'up-right'
+    } else if (newY === oldY) {
+      return 'right'
+    } else {
+      return 'down-right'
+    }
+  }
+
+  return 'none'
+}
+
+export const dartLizard: CreatureScriptFactory = (creature) => {
+  const tail = new Item({
+    name: 'dart lizard tail',
+  })
+
+  // move the tail with the lizard
+  const onMove = (api: ScriptApi): CreatureEvents['move'] => (_, x, y, oldX, oldY) => {
+    const direction = getDirectionOfMovement(x, y, oldX, oldY)
+
+    // the tail placement might seem backwards for the directon of movement
+    // but keep in mind the idea is the tail lags _behind_ the creature
+    switch (direction) {
+      case 'up-left':
+        api.moveMapItem(tail.id, x + 1, y + 1)
+        break
+
+      case 'up':
+        api.moveMapItem(tail.id, x, y + 1)
+        break
+
+      case 'up-right':
+        api.moveMapItem(tail.id, x - 1, y + 1)
+        break
+
+      case 'left':
+        api.moveMapItem(tail.id, x + 1, y)
+        break
+
+      case 'right':
+        api.moveMapItem(tail.id, x - 1, y)
+        break
+
+      case 'down-left':
+        api.moveMapItem(tail.id, x + 1, y - 1)
+        break
+
+      case 'down':
+        api.moveMapItem(tail.id, x, y - 1)
+        break
+
+      case 'down-right':
+        api.moveMapItem(tail.id, x - 1, y - 1)
+        break
+    }
+  }
+
+  return {
+    // add the lizard's tail to the map when created
+    onCreate: (api) => {
+      api.addMapItem(tail, creature.x, creature.y + 1)
+      creature.on('move', onMove(api))
+    },
+  }
+}

--- a/src/engine/scripts/dart-lizard.ts
+++ b/src/engine/scripts/dart-lizard.ts
@@ -1,6 +1,5 @@
-import { CreatureEvents } from 'engine/events'
 import { Item } from 'engine/item'
-import { CreatureScriptFactory, ScriptApi } from 'engine/script-api'
+import { CreatureScript, WorldScript } from 'engine/script-api'
 
 type Direction = 'up-left' | 'up' | 'up-right' | 'left' | 'right' | 'down-left' | 'down' | 'down-right' | 'none'
 
@@ -32,57 +31,56 @@ const getDirectionOfMovement = (newX: number, newY: number, oldX: number, oldY: 
   return 'none'
 }
 
-export const dartLizard: CreatureScriptFactory = (creature) => {
-  const tail = new Item({
-    name: 'dart lizard tail',
-  })
-
+export const dartLizard: CreatureScript & WorldScript = ({
   // move the tail with the lizard
-  const onMove = (api: ScriptApi): CreatureEvents['move'] => (_, x, y, oldX, oldY) => {
+  onMove: (api, creature, { x, y, oldX, oldY }) => {
     const direction = getDirectionOfMovement(x, y, oldX, oldY)
+
+    const tailId = creature.getScriptData<number>('tailId')
 
     // the tail placement might seem backwards for the directon of movement
     // but keep in mind the idea is the tail lags _behind_ the creature
     switch (direction) {
       case 'up-left':
-        api.moveMapItem(tail.id, x + 1, y + 1)
+        api.moveMapItem(tailId, x + 1, y + 1)
         break
 
       case 'up':
-        api.moveMapItem(tail.id, x, y + 1)
+        api.moveMapItem(tailId, x, y + 1)
         break
 
       case 'up-right':
-        api.moveMapItem(tail.id, x - 1, y + 1)
+        api.moveMapItem(tailId, x - 1, y + 1)
         break
 
       case 'left':
-        api.moveMapItem(tail.id, x + 1, y)
+        api.moveMapItem(tailId, x + 1, y)
         break
 
       case 'right':
-        api.moveMapItem(tail.id, x - 1, y)
+        api.moveMapItem(tailId, x - 1, y)
         break
 
       case 'down-left':
-        api.moveMapItem(tail.id, x + 1, y - 1)
+        api.moveMapItem(tailId, x + 1, y - 1)
         break
 
       case 'down':
-        api.moveMapItem(tail.id, x, y - 1)
+        api.moveMapItem(tailId, x, y - 1)
         break
 
       case 'down-right':
-        api.moveMapItem(tail.id, x - 1, y - 1)
+        api.moveMapItem(tailId, x - 1, y - 1)
         break
     }
-  }
+  },
+  // add the lizard's tail to the map when a lizard created
+  onCreate: (api, creature) => {
+    const tail = new Item({
+      name: 'dart lizard tail',
+    })
 
-  return {
-    // add the lizard's tail to the map when created
-    onCreate: (api) => {
-      api.addMapItem(tail, creature.x, creature.y + 1)
-      creature.on('move', onMove(api))
-    },
-  }
-}
+    const tailId = api.addMapItem(tail, creature.x, creature.y + 1)
+    creature.setScriptData('tailId', tailId)
+  },
+})

--- a/src/engine/scripts/dart-lizard.ts
+++ b/src/engine/scripts/dart-lizard.ts
@@ -2,17 +2,19 @@ import { Item } from 'engine/item'
 import { getAdjacentCoordinates } from 'engine/map/map-utils'
 import { random } from 'engine/random'
 import { CreatureScript, ScriptApi, WorldScript } from 'engine/script-api'
-import { countBy, get, join, map, some } from 'lodash/fp'
+import { countBy, get, some } from 'lodash/fp'
 import { distance } from 'math'
 
 import { getAge } from './age-sensor'
-import { getDetectedCreatures } from './creature-sensors'
 import { getFacing } from './facing-sensor'
+import { getStartledTurns, isStartled } from './startle-sensor'
+
+export const DefaultDartLizardSpeed = 100
 
 const DisappearChance = 10
 const SpawnChance = 3
 // minimum number of turns a lizard must stay on the map before darting away
-const MinimumAgeBeforeDisappearing = 7
+const MinimumAgeBeforeDisappearing = 75
 
 const DefaultMinPromiximityToPlayer = 5
 const DefaultMaxPromiximityToPlayer = 13
@@ -120,9 +122,15 @@ export const dartLizard: CreatureScript & WorldScript = {
     }
   },
   onTurnStart: ({ creature }, api) => {
-    const creatures = getDetectedCreatures(creature)
-    if (creatures.length > 0) {
-      api.showMessage(`Lizard will run because of: ${join(', ', map(get('name'), creatures))}`)
+    if (isStartled(creature)) {
+      if (getStartledTurns(creature) === 1) {
+        // the first turn of a startle, show a message
+        api.showMessage('Dart Lizard was startled!')
+      }
+
+      creature.speed = DefaultDartLizardSpeed * 1.5
+    } else {
+      creature.speed = DefaultDartLizardSpeed
     }
   },
   onTurnEnd: ({ creature }, api) => {

--- a/src/engine/scripts/facing-sensor.ts
+++ b/src/engine/scripts/facing-sensor.ts
@@ -1,0 +1,49 @@
+import { Creature } from 'engine/creature'
+import { CreatureScript } from 'engine/script-api'
+
+const KEY = 'sensor.facing'
+
+export type Direction = 'up-left' | 'up' | 'up-right' | 'left' | 'right' | 'down-left' | 'down' | 'down-right' | 'none'
+
+/** Uses the facing sensor to get the direction the creature is facing, based on it's last movement. */
+export const getFacing = (creature: Creature) => creature.getScriptData<Direction>(KEY, false)
+
+const getDirectionOfMovement = (newX: number, newY: number, oldX: number, oldY: number): Direction => {
+  if (newX < oldX) {
+    if (newY < oldY) {
+      return 'up-left'
+    } else if (newY === oldY) {
+      return 'left'
+    } else {
+      return 'down-left'
+    }
+  } else if (newX === oldX) {
+    if (newY < oldY) {
+      return 'up'
+    } else if (newY > oldY) {
+      return 'down'
+    }
+  } else if (newX > oldX) {
+    if (newY < oldY) {
+      return 'up-right'
+    } else if (newY === oldY) {
+      return 'right'
+    } else {
+      return 'down-right'
+    }
+  }
+
+  return 'none'
+}
+
+/** Sensor that determines which direction a creature is looking. */
+export const facingSensor: CreatureScript = {
+  onCreate: ({ creature }) => {
+    // just start with an arbitrary direction
+    creature.setScriptData(KEY, 'up')
+  },
+  onMove: ({ creature, x, y, xOld, yOld }) => {
+    const direction = getDirectionOfMovement(x, y, xOld, yOld)
+    creature.setScriptData(KEY, direction)
+  },
+}

--- a/src/engine/scripts/problem-of-scale.ts
+++ b/src/engine/scripts/problem-of-scale.ts
@@ -1,6 +1,6 @@
-import { Script } from 'engine/script-api'
+import { WorldScript } from 'engine/script-api'
 
-export const ProblemOfScale: Script = {
+export const ProblemOfScale: WorldScript = {
   onObjectiveProgress: (progress, objective, context) => {
     if (objective.id === 'problem_of_scale') {
       if (progress === 1) {

--- a/src/engine/scripts/problem-of-scale.ts
+++ b/src/engine/scripts/problem-of-scale.ts
@@ -1,4 +1,4 @@
-import { Script } from 'engine/engine'
+import { Script } from 'engine/script-api'
 
 export const ProblemOfScale: Script = {
   onObjectiveProgress: (progress, objective, context) => {

--- a/src/engine/scripts/startle-sensor.ts
+++ b/src/engine/scripts/startle-sensor.ts
@@ -1,0 +1,93 @@
+import { Creature } from 'engine/creature'
+import { CreatureScript } from 'engine/script-api'
+
+const KEY = 'sensor.startle'
+
+interface StartleDetails {
+  /** number of remaining turns until the creature calms down */
+  turnsRemaining: number
+
+  /** the creature that triggered the startle condition */
+  startledBy: Creature
+
+  /** how many turns since the creature was startled, which is zero if not startled */
+  turns: number
+}
+
+/**
+ * If the creature is startled, returns the creature that caused the startle. Otherwise, return
+ * undefined.
+ */
+export const getStartledBy = (creature: Creature) => {
+  return creature.getScriptData<StartleDetails>(KEY).startledBy
+}
+
+/**
+ * Returns true if the specified creature is startled. The creature must have a 'startleSensor'
+ * script, or else an error is thrown.
+ **/
+export const getStartledTurnsRemaining = (creature: Creature) => {
+  return creature.getScriptData<StartleDetails>(KEY).turnsRemaining
+}
+
+/**
+ * Returns how many turns the creature has been startled. Will be '0' if not startled, '1' the
+ * first turn the startle was triggered, and then is incremented by 1 each subsequent turn.
+ */
+export const getStartledTurns = (creature: Creature) => {
+  return creature.getScriptData<StartleDetails>(KEY).turns
+}
+
+/**
+ * Returns true if the specified creature is startled. The creature must have a 'startleSensor'
+ * script, or else an error is thrown.
+ **/
+export const isStartled = (creature: Creature) => getStartledTurnsRemaining(creature) !== 0
+
+export interface StartleSensorOptions {
+  /** the key used by the creatures detection sensor; (default: sensor.creatures) */
+  creaturesSensorKey?: string
+
+  /** the number of turns to flee after being startled */
+  turnsToFlee: number
+}
+
+/**
+ * Sensor script that detects a 'startle' condition triggered by the presence of other creatures,
+ * and returns how long the creature is startled for. This relies on another sensor to detect
+ * the creatures, and set them as script data (type: Creature[]) with a key specified when
+ * building this sensor (default: sensor.creatures).
+ */
+export const startleSensor = ({
+  creaturesSensorKey = 'sensor.creatures',
+  turnsToFlee,
+}: StartleSensorOptions): CreatureScript => ({
+  onCreate: ({ creature }) => {
+    creature.setScriptData(KEY, 0)
+  },
+  onTurnStart: ({ creature }) => {
+    const startle = creature.getScriptData<StartleDetails>(KEY, true)
+
+    const creatures = creature.getScriptData<Creature[]>(creaturesSensorKey, true) ?? []
+
+    const startledBy = creatures.length === 0 ? undefined : creatures[0]
+
+    const turnsRemaining = startledBy !== undefined
+      ? turnsToFlee
+      : startle !== undefined && startle.turnsRemaining > 0
+        ? startle.turnsRemaining - 1
+        : 0
+
+    const turns = turnsRemaining === 0
+      ? 0
+      : startle !== undefined && startle.turns > 0
+        ? startle?.turns + 1
+        : 1
+
+    creature.setScriptData(KEY, {
+      turnsRemaining,
+      startledBy: startledBy ?? startle?.startledBy,
+      turns,
+    })
+  },
+})

--- a/src/engine/scripts/startle-sensor.ts
+++ b/src/engine/scripts/startle-sensor.ts
@@ -53,8 +53,8 @@ export interface StartleSensorOptions {
 }
 
 /**
- * Sensor script that detects a 'startle' condition triggered by the presence of other creatures,
- * and returns how long the creature is startled for. This relies on another sensor to detect
+ * Sensor script that detects a 'startle' condition. A creature is startled if it is attacked,
+ * or senses the presence of other creatures. This relies on another sensor to detect
  * the creatures, and set them as script data (type: Creature[]) with a key specified when
  * building this sensor (default: sensor.creatures).
  */
@@ -64,6 +64,13 @@ export const startleSensor = ({
 }: StartleSensorOptions): CreatureScript => ({
   onCreate: ({ creature }) => {
     creature.setScriptData(KEY, 0)
+  },
+  onDefend: ({ attack, creature }) => {
+    creature.setScriptData(KEY, {
+      startledBy: attack.attacker,
+      turnsRemaining: turnsToFlee,
+      turns: 1,
+    })
   },
   onTurnStart: ({ creature }) => {
     const startle = creature.getScriptData<StartleDetails>(KEY, true)

--- a/src/engine/sensors/last-aggressor.ts
+++ b/src/engine/sensors/last-aggressor.ts
@@ -1,5 +1,5 @@
-import { Attack } from 'engine/combat'
 import { Creature, Sensor } from 'engine/creature'
+import { CreatureEvents } from 'engine/events/creature-events'
 
 export class LastAggressorSensor implements Sensor<Creature | undefined> {
   /** the last creature to attack this one, or undefined */
@@ -11,7 +11,8 @@ export class LastAggressorSensor implements Sensor<Creature | undefined> {
     this._creature.on('defend', this._onDefend.bind(this))
   }
 
-  private _onDefend ({ attacker }: Attack) {
+  private _onDefend ({ attack }: CreatureEvents['defend']) {
+    const attacker = attack.attacker
     if (attacker instanceof Creature) {
       this._lastAggressor = attacker
     }

--- a/src/engine/terrain-db.ts
+++ b/src/engine/terrain-db.ts
@@ -27,7 +27,7 @@ const terrainTypeArray = [
   },
   {
     id: 'heavy_brush',
-    traversable: false,
+    traversable: true,
   },
   {
     id: 'light_brush_1',

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -107,7 +107,7 @@ export interface Actor extends Entity {
   /**
    * Called by the engine after each turn passes.
    */
-  turnEnded: (world: World) => void
+  onTurnEnd: () => void
 }
 
 /** A Positionable entity has coordinates on the map grid. */

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -108,6 +108,11 @@ export interface Actor extends Entity {
    * Called by the engine after each turn passes.
    */
   onTurnEnd: () => void
+
+  /**
+   * Called by the engine before each turn begins.
+   */
+  onTurnStart: () => void
 }
 
 /** A Positionable entity has coordinates on the map grid. */

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -223,6 +223,7 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
   private _registerCreature (creature: Creature) {
     this._creatures.push(creature)
     creature.on('attack', this._logAttack.bind(this))
+    this.map.setCreature(creature.x, creature.y, creature)
     this.emit('creatureSpawn', creature)
   }
 
@@ -304,6 +305,8 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
       // TODO: think through 'undefined' results from monsters
       creature.initiative -= 100
     }
+
+    creature.onTurnEnd()
 
     this._nextActor = (this._nextActor + 1) % this._creatures.length
 

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -155,11 +155,7 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
     do {
       // check if we are waiting for visual effects
       if (this._deferUntil !== undefined && Date.now() < this._deferUntil) {
-        if (!stillWaiting) {
-          this.emit('update')
-        }
-
-        return
+        break
       } else {
         this._deferUntil = undefined
       }
@@ -172,8 +168,13 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
       }
     } while (!exit && this._nextActor !== 0)
 
-    // emit a final update at the end of the turn if we aren't waiting
     if (!stillWaiting) {
+      // if the next actor's index is zero, we looped through all creatures -- emit a turn event
+      if (this._nextActor === 0) {
+        this.emit('turn')
+      }
+
+      // emit a final update at the end of the loop if we aren't waiting
       this.emit('update')
     }
   }

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -307,8 +307,8 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
     }
 
     creature.onTurnEnd()
-
     this._nextActor = (this._nextActor + 1) % this._creatures.length
+    this._creatures[this._nextActor].onTurnStart()
 
     // update initaitive for this turn (we add it _after_ decrementing to
     // more easily handle the 'waiting for input' case)

--- a/src/engine/world.ts
+++ b/src/engine/world.ts
@@ -7,6 +7,7 @@ import { AttackResult } from './combat'
 import { Creature } from './creature'
 import { Dungeon } from './dungeon/dungeon'
 import { WorldEvents } from './events'
+import { Item } from './item'
 import { ExpeditionMap } from './map/map'
 import { Player } from './player'
 import { random } from './random'
@@ -18,7 +19,8 @@ import { Updateable } from './types'
  * will be checked periodically, and once they provide an action the loop will resume.
  */
 export class World extends TypedEventEmitter<WorldEvents> implements Updateable {
-  public readonly map: ExpeditionMap
+  private _dungeon: Dungeon | undefined
+  private _map = new ExpeditionMap()
 
   // if true, we do not process updates (the user has requested we wait)
   public paused = false
@@ -29,6 +31,9 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
   // all the world's creatures
   private _creatures: Creature[] = []
 
+  // all the world's items
+  private _items: { [k in Item['id']]?: Item } = {}
+
   // all player-readable log messages from this game
   private _messages: string[] = []
 
@@ -37,21 +42,22 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
 
   private _player: Player
 
-  constructor (
-    public readonly dungeon: Dungeon
-  ) {
+  constructor () {
     super()
 
-    this.map = dungeon.createMap()
-
     this._player = new Player()
-    this._initializePlayer()
-
-    forEach((creature) => {
-      this._registerCreature(creature)
-    }, dungeon.creatures)
 
     this.logMessage('Expedition started.')
+  }
+
+  public initializeFromDungeon (dungeon: Dungeon) {
+    this._dungeon = dungeon
+    this._map = dungeon.createMap()
+
+    this._initializePlayer()
+
+    this._dungeon.forEachCreature(this._registerCreature.bind(this))
+    this._dungeon.forEachItem(this.addItemToMap.bind(this))
   }
 
   /**
@@ -62,8 +68,26 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
     this.emit('message', message)
   }
 
+  public get dungeon () {
+    return this._dungeon
+  }
+
+  public get map () {
+    return this._map
+  }
+
   public get creatures (): readonly Creature[] {
     return this._creatures
+  }
+
+  /** Adds a new creature to the world. It will emit any 'on-spawn' type of events. */
+  public addCreature (creature: Creature) {
+    this._registerCreature(creature)
+  }
+
+  /** Removes a creature from the map and world world. It will not emit a 'death' event. */
+  public removeCreature (creature: Creature) {
+    this._removeCreature(creature)
   }
 
   /**
@@ -71,6 +95,28 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
    */
   public getCreature (id: number) {
     return find((creature) => creature.id === id, this._creatures)
+  }
+
+  /** Adds a new item to the world, placing it in the specified map cell. */
+  public addItemToMap (item: Item, x: number, y: number) {
+    this._registerItem(item)
+    this._map.addItem(x, y, item)
+  }
+
+  /** Removes an item from the world, including any container or map cell holding it */
+  public removeItem ({ id }: Item) {
+    const item = this._items[id]
+    if (item !== undefined) {
+      item.container?.removeItem(item)
+      delete this._items[item.id]
+    }
+  }
+
+  /**
+   * Gets the item with a specified ID. If there is no item with that ID, will return undefined.
+   */
+  public getItem (id: number) {
+    return this._items[id]
   }
 
   /** Returns flag indicating if the current expedition reached an end condition. */
@@ -136,7 +182,7 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
     this._registerCreature(this._player)
     this.map.setCreature(this._player.x, this._player.y, this._player)
 
-    this._player.on('move', (x, y) => {
+    this._player.on('move', (_, x, y) => {
       const itemNames = map(get('name'), this.map.getItems(x, y))
       if (itemNames.length > 2) {
         // list of three or more, so use commas with 'and'
@@ -175,6 +221,15 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
   private _registerCreature (creature: Creature) {
     this._creatures.push(creature)
     creature.on('attack', this._logAttack.bind(this))
+    this.emit('creatureSpawn', creature)
+  }
+
+  /**
+   * Registers a newly created item with the world. This includes adding it to the item list,
+   * and registering any event listeners.
+   */
+  private _registerItem (item: Item) {
+    this._items[item.id] = item
   }
 
   private _removeDeadCreatures () {
@@ -186,9 +241,10 @@ export class World extends TypedEventEmitter<WorldEvents> implements Updateable 
         this.logMessage(`${creature.type.name} is dead!`)
 
         // drop the creatures inventory
+        // we clone the inventory item array, since moving items out of it will mess up iteration
         forEach((item) => {
           this.map.getCell(creature.x, creature.y).addItem(item)
-        }, creature.inventory.items)
+        }, [...creature.inventory.items])
 
         this.emit('creatureDeath', creature)
       }, deadCreatures)

--- a/src/enumerate.ts
+++ b/src/enumerate.ts
@@ -1,0 +1,10 @@
+// See: https://github.com/microsoft/TypeScript/issues/13298#issuecomment-654906323
+
+type ValueOf<T> = T[keyof T]
+type NonEmptyArray<T> = [T, ...T[]]
+type MustInclude<T, U extends T[]> =
+  [T] extends [ValueOf<U>]
+    ? U
+    : never;
+
+export const enumerate = <T>() => <U extends NonEmptyArray<T>>(...elements: MustInclude<T, U>) => elements

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,8 +1,29 @@
 type Point = { x: number; y: number }
 
-export const distance = (cell1: Point, cell2: Point) => {
-  const xPart = cell2.x - cell1.x
-  const yPart = cell2.y - cell1.y
+export function distance (x1: number, y1: number, x2: number, y2: number): number
+export function distance (cell1: Point, cell2: Point): number
+export function distance (
+  ...[cell1OrX1, cell2orY1, x2OrUndefined, y2OrUndefined]: [Point, Point] | [number, number, number, number]
+): number {
+  let x1 = 0
+  let y1 = 0
+  let x2 = 0
+  let y2 = 0
+
+  if (typeof cell1OrX1 === 'object') {
+    x1 = cell1OrX1.x
+    y1 = cell1OrX1.y
+    x2 = (cell2orY1 as Point).x
+    y2 = (cell2orY1 as Point).y
+  } else {
+    x1 = cell1OrX1
+    y1 = cell2orY1 as number
+    x2 = x2OrUndefined as number
+    y2 = y2OrUndefined as number
+  }
+
+  const xPart = x2 - x1
+  const yPart = y2 - y1
   return Math.sqrt((xPart * xPart) + (yPart * yPart))
 }
 

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -1,6 +1,7 @@
 import './expedition-screen.css'
 
 import { AttackAction } from 'engine/actions/attack'
+import { DoNothing } from 'engine/actions/do-nothing'
 import { MoveByAction } from 'engine/actions/move-by'
 import { Action } from 'engine/types'
 import { useCallback, useEffect, useState } from 'react'
@@ -86,6 +87,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
     [keyMap.MoveLeft]: executePlayerMove(-1, 0),
     [keyMap.MoveRight]: executePlayerMove(1, 0),
     [keyMap.MoveUp]: executePlayerMove(0, -1),
+    [keyMap.Wait]: () => executeTurn(DoNothing),
   })
 
   useEffect(() => {

--- a/src/ui/components/map-panel.tsx
+++ b/src/ui/components/map-panel.tsx
@@ -155,9 +155,9 @@ export const MapPanel = ({
     )
 
     sceneGraphRef.current = new MapSceneGraph(app, CellWidth, CellHeight)
-    app.ticker.add((delta) => {
+    app.ticker.add((_delta) => {
       if (sceneGraphRef.current) {
-        sceneGraphRef.current.update(delta)
+        sceneGraphRef.current.update()
       }
     })
 

--- a/src/ui/components/map-scene-graph.ts
+++ b/src/ui/components/map-scene-graph.ts
@@ -80,7 +80,7 @@ class CreatureTile extends AbstractTile {
     this._creature.on('defend', () => {
       this.highlight(missed())
     })
-    this._creature.on('damaged', (amount) => {
+    this._creature.on('damaged', ({ amount }) => {
       this.highlight(damaged(amount > 9 ? '*' : `${amount}`))
     })
   }

--- a/src/ui/components/speech-panel.tsx
+++ b/src/ui/components/speech-panel.tsx
@@ -1,6 +1,6 @@
 import './narration-panel.css'
 
-import { Speech } from 'engine/engine'
+import { Speech } from 'engine/script-api'
 import { noop } from 'lodash'
 import { useCallback, useEffect, useState } from 'react'
 import { useKeyHandler } from 'ui/hooks/use-key-handler'

--- a/src/ui/components/speech-window.tsx
+++ b/src/ui/components/speech-window.tsx
@@ -1,4 +1,4 @@
-import { Speech } from 'engine/engine'
+import { Speech } from 'engine/script-api'
 import { noop } from 'lodash'
 import { useCallback, useEffect, useState } from 'react'
 import { useEngine } from 'ui/hooks/use-engine'

--- a/src/ui/key-map.ts
+++ b/src/ui/key-map.ts
@@ -7,6 +7,7 @@ export interface KeyMap {
   MoveRight: string
   OpenInventory: string
   OpenObjectives: string
+  Wait: string
 }
 
 const KeyMaps = {
@@ -19,6 +20,7 @@ const KeyMaps = {
     MoveRight: 'f',
     OpenInventory: 'b',
     OpenObjectives: 'j',
+    Wait: ' ',
   },
   EveryoneElse: {
     Confirm: 'Enter',
@@ -29,6 +31,7 @@ const KeyMaps = {
     MoveRight: 'd',
     OpenInventory: 'i',
     OpenObjectives: 'j',
+    Wait: ' ',
   },
 }
 


### PR DESCRIPTION
- Update item handling to require world registration, track the container, and automatically remove from old container when stowing.
- Extract script API and refactor engine to provide an implementation.
- Add dart lizard and tail scripts.
- Add scriptData to creature. Share script instances between all creatures referencing it.
- Add script API function for selecting random tiles on the map.
- Add script API functions for adding creatures and selecting random tiles on the map.
- Replace 'onUpdate' script method with 'onTurn'.
- Add script to cause dart lizards to spawn near heavy brush.
- Rework event system to allow easier adding of new event types.
- Update Dart Lizards to periodically dash into the woods.
- Lizards will wait a minimum # of turns after appearing before darting away.
- Add sensor to detect creatures 'in front' of the sensing creature.
- Add startle behavior to dart lizards.
- Cause startle when being attacked.
- Add ability to wait and some tuning on dart lizards.
