### PR TITLE
feat: limit visibility based on terrain obstructions

### DIFF
--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -15,7 +15,9 @@ import { ageSensor } from './scripts/age-sensor'
 import { creaturesInFrontSensor } from './scripts/creature-sensors'
 import { dartLizard, DefaultDartLizardSpeed } from './scripts/dart-lizard'
 import { facingSensor } from './scripts/facing-sensor'
+import { player } from './scripts/player'
 import { startleSensor } from './scripts/startle-sensor'
+import { tileVisibilitySensor } from './scripts/tile-visibility-sensor'
 import { Generator } from './spawnable'
 
 export type CreatureType = Readonly<{
@@ -107,6 +109,7 @@ const creatureTypeArray = [
     id: 'player',
     melee: 1,
     name: 'Player',
+    scripts: [tileVisibilitySensor, player],
     speed: 100,
   },
 ] as const

--- a/src/engine/creature.ts
+++ b/src/engine/creature.ts
@@ -122,10 +122,10 @@ export class Creature extends CreatureEventEmitter implements
    * Gets the script property with the given key from the creature. If the optional property is
    * false, an error will be thrown if it does not exist.
    */
-  public getScriptData <T = unknown>(key: string): Readonly<T>;
-  public getScriptData <T = unknown>(key: string, optional?: false): Readonly<T>;
-  public getScriptData <T = unknown>(key: string, optional: true): Readonly<T> | undefined
-  public getScriptData <T = unknown> (key: string, optional = false): Readonly<T> | undefined {
+  public getScriptData <T = unknown>(key: string): T;
+  public getScriptData <T = unknown>(key: string, optional?: false): T;
+  public getScriptData <T = unknown>(key: string, optional: true): T | undefined
+  public getScriptData <T = unknown> (key: string, optional = false): T | undefined {
     const data = this._scriptData[key]
     if (!optional && data === undefined) {
       throw new Error(`Required script data with key '${key}' not found on creature ${this.id} (name=${this.name})`)

--- a/src/engine/dungeon/create-forest.ts
+++ b/src/engine/dungeon/create-forest.ts
@@ -63,13 +63,9 @@ class ForestPathRegion extends BasicRegion {
       y: random(this._region2.top, this._region2.bottom),
     }
 
-    // eslint-disable-next-line no-console
-    console.log('p1 to p2', point1, point2)
     const path = map.getPath(point1, point2, {
       costFunction: randomCosts({ maximumCost: 1000 }),
     })
-    // eslint-disable-next-line no-console
-    console.log('done')
 
     const createPath = (x: number, y: number, overwrite = false) => {
       if (overwrite || map.getTerrain(x, y) === TerrainTypes.heavy_brush) {

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -16,7 +16,7 @@ import { EventHandlerName } from './events/types'
 import { Item } from './item'
 import { MapCell } from './map/map'
 import { random } from './random'
-import { MapTile, ScriptApi, Speech } from './script-api'
+import { initializePlayer } from './scripts/player'
 
 class GameController implements ScriptApi {
   constructor (
@@ -196,9 +196,13 @@ export class Engine extends TypedEventEmitter<EngineEvents> implements Updateabl
     this.attach(this._world)
     this._world.initializeFromDungeon(this._campaign.createNextDungeon())
 
+    // initialize the campaign
     forEach((script) => {
       script.initialize?.(this._scriptApi)
     }, this._campaign.scripts)
+
+    // initialize the player
+    initializePlayer.initialize?.(this._scriptApi)
   }
 
   public get world () {

--- a/src/engine/engine.tsx
+++ b/src/engine/engine.tsx
@@ -14,8 +14,9 @@ import { CreatureEventNames, CreatureEvents } from './events/creature-events'
 import { EventManager, EventManagerEvents } from './events/event-manager'
 import { EventHandlerName } from './events/types'
 import { Item } from './item'
-import { MapCell } from './map/map'
+import { MapCell, MapTile } from './map/map'
 import { random } from './random'
+import { ScriptApi, Speech } from './script-api'
 import { initializePlayer } from './scripts/player'
 
 class GameController implements ScriptApi {
@@ -99,9 +100,7 @@ class GameController implements ScriptApi {
   }
 
   public getMapTile (x: number, y: number): MapTile | undefined {
-    return this._world.map.hasCell(x, y)
-      ? this._world.map.getCell(x, y)
-      : undefined
+    return this._world.map.getMapTile(x, y)
   }
 
   public addMapItem (item: Item, x: number, y: number): number {

--- a/src/engine/map/cast-ray.ts
+++ b/src/engine/map/cast-ray.ts
@@ -1,0 +1,18 @@
+import { reverse } from 'lodash/fp'
+
+import { plotLine } from './plot-line'
+
+/** Casts a ray from pStart to pEnd, and returns an array containing all points along it. */
+export const castRay = (
+  xStart: number,
+  yStart: number,
+  xEnd: number,
+  yEnd: number
+): { x: number; y: number}[] => {
+  const result: { x: number; y: number}[] = []
+  plotLine(xStart, yStart, xEnd, yEnd, (x, y) => result.push({ x, y }))
+
+  // line drawing algorithm returns result in an unspecified order (start->end or end->start),
+  // so we check which we got and reverse it if needed, so that rays are always cast start->end
+  return result[0].x === xStart && result[0].y === yStart ? result : reverse(result)
+}

--- a/src/engine/map/plot-line.ts
+++ b/src/engine/map/plot-line.ts
@@ -1,0 +1,88 @@
+const plotLineLow = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  point: (x: number, y: number) => void
+) => {
+  const dx = x1 - x0
+  let dy = y1 - y0
+  let yi = 1
+  if (dy < 0) {
+    yi = -1
+    dy = -dy
+  }
+
+  let D = (2 * dy) - dx
+  let y = y0
+
+  for (let x = x0; x <= x1; x++) {
+    point(x, y)
+
+    if (D > 0) {
+      y = y + yi
+      D = D + (2 * (dy - dx))
+    } else {
+      D = D + 2 * dy
+    }
+  }
+}
+
+const plotLineHigh = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  point: (x: number, y: number) => void
+) => {
+  let dx = x1 - x0
+  const dy = y1 - y0
+  let xi = 1
+  if (dx < 0) {
+    xi = -1
+    dx = -dx
+  }
+
+  let D = (2 * dx) - dy
+  let x = x0
+
+  for (let y = y0; y <= y1; y++) {
+    point(x, y)
+
+    if (D > 0) {
+      x = x + xi
+      D = D + (2 * (dx - dy))
+    } else {
+      D = D + 2 * dx
+    }
+  }
+}
+
+/**
+ * Plots a line using Bresenham's line algorithm. For each point along the line, the 'point' callback
+ * is called with the (x, y) coordinate of the point. Note that this implementation is directly lifted and
+ * shifted from the pseudo-code on Wikipedia for this algorithm.
+ *
+ * @see https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
+ */
+export const plotLine = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  point: (x: number, y: number) => void
+) => {
+  if (Math.abs(y1 - y0) < Math.abs(x1 - x0)) {
+    if (x0 > x1) {
+      plotLineLow(x1, y1, x0, y0, point)
+    } else {
+      plotLineLow(x0, y0, x1, y1, point)
+    }
+  } else {
+    if (y0 > y1) {
+      plotLineHigh(x1, y1, x0, y0, point)
+    } else {
+      plotLineHigh(x0, y0, x1, y1, point)
+    }
+  }
+}

--- a/src/engine/script-api.ts
+++ b/src/engine/script-api.ts
@@ -3,7 +3,7 @@ import { CreatureTypeId } from './creature-db'
 import { CreatureEvents } from './events/creature-events'
 import { EventHandlerName } from './events/types'
 import { Item } from './item'
-import { MapCell } from './map/map'
+import { MapTile, TileProvider } from './map/map'
 import { Objective } from './objective'
 
 /** A single piece of content that should be displayed during a dialog 'cutscene'. */
@@ -14,15 +14,6 @@ export interface Speech {
   /** the actual message (description, dialog, etc.) */
   message: string
 }
-
-export type MapTile = Readonly<Pick<MapCell,
-'creature' |
-'containsItem' |
-'items' |
-'terrain'|
-'x' |
-'y'
->>
 
 export type CreatureApi = Readonly<{
   /**
@@ -58,7 +49,7 @@ export type CreatureApi = Readonly<{
 }>
 
 /** API exposed to scripts attached to creatures, items, etc. */
-export interface ScriptApi extends CreatureApi {
+export interface ScriptApi extends CreatureApi, TileProvider {
   /**
    * Retrieves the map tile at the given coordinates, or undefined if it is outside the existing map.
    */

--- a/src/engine/scripts/creature-sensors.ts
+++ b/src/engine/scripts/creature-sensors.ts
@@ -1,5 +1,6 @@
 import { Creature } from 'engine/creature'
-import { CreatureScript, MapTile } from 'engine/script-api'
+import { MapTile } from 'engine/map/map'
+import { CreatureScript } from 'engine/script-api'
 import { compact, filter, map } from 'lodash/fp'
 
 import { getFacing } from './facing-sensor'

--- a/src/engine/scripts/player.ts
+++ b/src/engine/scripts/player.ts
@@ -1,0 +1,28 @@
+import { Player } from 'engine/player'
+import { CreatureScript, WorldScript } from 'engine/script-api'
+import { get, initial, join, last, map } from 'lodash/fp'
+
+export const initializePlayer: WorldScript = {
+  initialize: (api) => {
+    api.addCreature(new Player())
+  },
+}
+
+/**
+ * Scripted behavior for the creature representing the player.
+ */
+export const player: CreatureScript & WorldScript = {
+  onMove: ({ x, y }, api) => {
+    const itemNames = map(get('name'), api.getMapTile(x, y)?.items)
+    if (itemNames.length > 2) {
+      // list of three or more, so use commas with 'and'
+      const listContents = [...initial(itemNames), `and ${last(itemNames)}`]
+      api.showMessage(`You see some items here: ${join(', ', listContents)}.`)
+    } else if (itemNames.length === 2) {
+      // two items, just put 'and' between them
+      api.showMessage(`You see ${itemNames[0]} and ${itemNames[1]} here.`)
+    } else if (itemNames.length === 1) {
+      api.showMessage(`You see a ${itemNames[0]} here.`)
+    }
+  },
+}

--- a/src/engine/scripts/tile-visibility-sensor.ts
+++ b/src/engine/scripts/tile-visibility-sensor.ts
@@ -1,6 +1,12 @@
 import { Creature } from 'engine/creature'
+import { castRay } from 'engine/map/cast-ray'
 import { CreatureScript, ScriptApi } from 'engine/script-api'
+import { forEach } from 'lodash/fp'
 import { distance } from 'math'
+
+// upper limit to sight, hard-coded for now
+// TODO: make this depend on creature, time of day, environment, etc.
+const MaximumSightDistance = 20
 
 // key for the cache of visibility results we've alread calculated
 const KEY_CACHE = 'sensor.tile-visibility.cache'
@@ -14,27 +20,64 @@ interface TileVisibilitySettings {
   distanceLimit: number
 }
 
-/**
- * Determines if the given creature can see the tile at (x, y), given it's current state.
- * The API is used to retrieve tile information needed for performing the calculations.
- */
-export const isTileVisibleTo = (creature: Creature, x: number, y: number, _api: Pick<ScriptApi, 'getMapTile'>) => {
+const isWithinSightRange = (creature: Creature, x: number, y: number) => {
   const settings = creature.getScriptData<TileVisibilitySettings>(KEY_SETTINGS, false)
   const d = distance(creature.x, creature.y, x, y)
   return d <= settings.distanceLimit
 }
 
+/**
+ * Determines if the given creature can see the tile at (x, y), given it's current state.
+ * The API is used to retrieve tile information needed for performing the calculations.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const isTileVisibleTo = (creature: Creature, x: number, y: number, api: Pick<ScriptApi, 'getMapTile'>) => {
+  if (!isWithinSightRange(creature, x, y)) {
+    return false
+  }
+
+  const cache = creature.getScriptData<boolean[][]>(KEY_CACHE)
+  if (cache[y]?.[x] === undefined) {
+    const tilesInRay = castRay(creature.x, creature.y, x, y)
+
+    let blocked = false
+    forEach(({ x, y }) => {
+      if (cache[y] === undefined) {
+        cache[y] = []
+      }
+
+      // we can always see our tile, and it doesn't block immediate neighbors
+      if (creature.x === x && creature.y === y) {
+        cache[y][x] = true
+        return
+      }
+
+      cache[y][x] = !blocked
+      const tile = api.getMapTile(x, y)
+      if (tile !== undefined) {
+        // if this is a blocking tile, block all the tiles behind it
+        if (tile.terrain.blocksLineOfSight) {
+          blocked = true
+        }
+      }
+    }, tilesInRay)
+  }
+
+  return cache[y]?.[x] ?? false
+}
+
 /** sensor supporting line-of-sight calculations for tiles in a creature-aware manner */
 export const tileVisibilitySensor: CreatureScript = {
   onCreate: ({ creature }) => {
+    creature.setScriptData(KEY_CACHE, [])
     creature.setScriptData<TileVisibilitySettings>(KEY_SETTINGS, {
-      distanceLimit: 12,
+      distanceLimit: MaximumSightDistance,
     })
   },
   onTurnStart: ({ creature }) => {
     creature.setScriptData(KEY_CACHE, [])
     creature.setScriptData<TileVisibilitySettings>(KEY_SETTINGS, {
-      distanceLimit: 12,
+      distanceLimit: MaximumSightDistance,
     })
   },
 }

--- a/src/engine/scripts/tile-visibility-sensor.ts
+++ b/src/engine/scripts/tile-visibility-sensor.ts
@@ -1,0 +1,40 @@
+import { Creature } from 'engine/creature'
+import { CreatureScript, ScriptApi } from 'engine/script-api'
+import { distance } from 'math'
+
+// key for the cache of visibility results we've alread calculated
+const KEY_CACHE = 'sensor.tile-visibility.cache'
+// key for the data object controll the settings to use when calculating visibility
+// this is built by our script, and is based on a combination of user configuration
+// and the creature's state
+const KEY_SETTINGS = 'sensor.tile-visibility.settings'
+
+interface TileVisibilitySettings {
+  /** the maximum distanced, in tiles, that can be seen */
+  distanceLimit: number
+}
+
+/**
+ * Determines if the given creature can see the tile at (x, y), given it's current state.
+ * The API is used to retrieve tile information needed for performing the calculations.
+ */
+export const isTileVisibleTo = (creature: Creature, x: number, y: number, _api: Pick<ScriptApi, 'getMapTile'>) => {
+  const settings = creature.getScriptData<TileVisibilitySettings>(KEY_SETTINGS, false)
+  const d = distance(creature.x, creature.y, x, y)
+  return d <= settings.distanceLimit
+}
+
+/** sensor supporting line-of-sight calculations for tiles in a creature-aware manner */
+export const tileVisibilitySensor: CreatureScript = {
+  onCreate: ({ creature }) => {
+    creature.setScriptData<TileVisibilitySettings>(KEY_SETTINGS, {
+      distanceLimit: 12,
+    })
+  },
+  onTurnStart: ({ creature }) => {
+    creature.setScriptData(KEY_CACHE, [])
+    creature.setScriptData<TileVisibilitySettings>(KEY_SETTINGS, {
+      distanceLimit: 12,
+    })
+  },
+}

--- a/src/engine/terrain-db.ts
+++ b/src/engine/terrain-db.ts
@@ -1,6 +1,9 @@
 import { keys, reduce } from 'lodash/fp'
 
 export interface TerrainType {
+  /** if true, then this type of terrain blocks line of sight */
+  blocksLineOfSight: boolean
+
   /** unique id for this type of terrain */
   id: TerrainTypeId
 
@@ -11,50 +14,62 @@ export interface TerrainType {
 const terrainTypeArray = [
   {
     id: 'default',
+    blocksLineOfSight: true,
     traversable: false,
   },
   {
     id: 'brambles',
+    blocksLineOfSight: true,
     traversable: true,
   },
   {
     id: 'door',
+    blocksLineOfSight: true,
     traversable: true,
   },
   {
     id: 'floor',
+    blocksLineOfSight: false,
     traversable: true,
   },
   {
     id: 'heavy_brush',
+    blocksLineOfSight: true,
     traversable: true,
   },
   {
     id: 'light_brush_1',
+    blocksLineOfSight: false,
     traversable: true,
   },
   {
     id: 'light_brush_2',
+    blocksLineOfSight: false,
     traversable: true,
   },
   {
     id: 'light_brush_3',
+    blocksLineOfSight: false,
     traversable: true,
   },
   {
     id: 'path',
+    blocksLineOfSight: false,
     traversable: true,
   },
   {
     id: 'water',
+    blocksLineOfSight: false,
     traversable: false,
   },
   {
     id: 'water_shallow',
+    blocksLineOfSight: false,
     traversable: true,
   },
   {
     id: 'wall',
+    blocksLineOfSight: true,
     traversable: false,
   },
 ] as const

--- a/src/ui/components/map-scene-graph.ts
+++ b/src/ui/components/map-scene-graph.ts
@@ -2,6 +2,7 @@ import { Creature } from 'engine/creature'
 import { MapCell } from 'engine/map/map'
 import { MapSymbol } from 'engine/map/map-symbol'
 import { getCreatureSymbol, getItemSymbol, getTerrainSymbol, withDefaultBackground } from 'engine/map/map-symbolizer'
+import { isTileVisibleTo } from 'engine/scripts/tile-visibility-sensor'
 import { World } from 'engine/world'
 import { compact, forEach, get, keys, map as lodashMap, values, without } from 'lodash/fp'
 import * as PIXI from 'pixi.js'
@@ -212,7 +213,8 @@ export class MapSceneGraph {
       if (tile.x < xOffset ||
         tile.x > (xOffset + viewWidth + 1) ||
         tile.y < yOffset ||
-        tile.y > (yOffset + viewHeight + 1)
+        tile.y > (yOffset + viewHeight + 1) ||
+        !isTileVisibleTo(world.player, tile.x, tile.y, world.map)
       ) {
         tile.inFrame = false
       } else {

--- a/src/ui/components/map-scene-graph.ts
+++ b/src/ui/components/map-scene-graph.ts
@@ -130,9 +130,6 @@ class MapCellTile extends AbstractTile {
   public update () {
     this.container.position.set(this.x * this.cellWidth, this.y * this.cellHeight)
 
-    // hide ourselves if a creature is here, it's rendering takes precendence
-    this.setVisible(this._cell.creature === undefined)
-
     if (this._cell.items.length > 0) {
       this.setMapSymbol(withDefaultBackground(this._cell, getItemSymbol(this._cell.items)))
     } else {


### PR DESCRIPTION
- Remove special handling from player creature, and initialize it via standard scripts.
- Limit visibility of the player based on terrain.
- Add post-processing to improve wall visibility from ray casting.
