### PR TITLE
feat: add mouse tooltips for map elements

### DIFF
--- a/src/engine/creature-db.ts
+++ b/src/engine/creature-db.ts
@@ -27,6 +27,9 @@ export type CreatureType = Readonly<{
   /** defense stat for this creature */
   defense: number
 
+  /** optional description of this creature, used when it is examined */
+  description?: string
+
   /** maximum health of creatures of this type */
   healthMax: number
 
@@ -57,6 +60,8 @@ const creatureTypeArray = [
   {
     createBehavior: () => BehaviorChain(startle(), maybeIdle(MoveRandomlyBehavior(), 50)),
     defense: 0,
+    description: `This long, snake-like reptile is covered in yellow and green scales arranged in a mossy pattern. 
+At rest, its mouth tilts upward giving you a clear view of the dual, fin-like crests atop it's head.`,
     healthMax: 2,
     id: 'dart_lizard',
     lootTable: MonsterLootTables[1],
@@ -105,6 +110,7 @@ const creatureTypeArray = [
     // player creates its own behavior, so implement a noop here
     createBehavior: () => () => undefined,
     defense: 0,
+    description: 'It\'s you!',
     healthMax: 10,
     id: 'player',
     melee: 1,

--- a/src/engine/terrain-db.ts
+++ b/src/engine/terrain-db.ts
@@ -45,7 +45,7 @@ const terrainTypeArray = [
   {
     id: 'heavy_brush',
     blocksLineOfSight: true,
-    name: 'Lost in the Forest',
+    name: 'Deep Forest',
     traversable: true,
   },
   {

--- a/src/engine/terrain-db.ts
+++ b/src/engine/terrain-db.ts
@@ -4,6 +4,12 @@ export interface TerrainType {
   /** if true, then this type of terrain blocks line of sight */
   blocksLineOfSight: boolean
 
+  /** optional default description for this terrain type */
+  description?: string
+
+  /** default tile name for this terrain type, if the map doesn't override it */
+  name: string
+
   /** unique id for this type of terrain */
   id: TerrainTypeId
 
@@ -15,61 +21,75 @@ const terrainTypeArray = [
   {
     id: 'default',
     blocksLineOfSight: true,
+    name: 'Unknown Region',
     traversable: false,
   },
   {
     id: 'brambles',
     blocksLineOfSight: true,
+    name: 'Thick Brambles',
     traversable: true,
   },
   {
     id: 'door',
     blocksLineOfSight: true,
+    name: 'A Doorway',
     traversable: true,
   },
   {
     id: 'floor',
     blocksLineOfSight: false,
+    name: 'a floor',
     traversable: true,
   },
   {
     id: 'heavy_brush',
     blocksLineOfSight: true,
+    name: 'Lost in the Forest',
     traversable: true,
   },
   {
     id: 'light_brush_1',
     blocksLineOfSight: false,
+    name: 'Flower-Filled Clearing',
     traversable: true,
   },
   {
     id: 'light_brush_2',
     blocksLineOfSight: false,
+    name: 'An Open Space',
     traversable: true,
   },
   {
     id: 'light_brush_3',
     blocksLineOfSight: false,
+    name: 'Forest',
     traversable: true,
   },
   {
     id: 'path',
     blocksLineOfSight: false,
+    description: `This narrow dirt trail has been partially overtaken by brush. Although you see no clear footprints
+or wagon tracks, something has kept the surrounding forest from reclaiming this space.`,
+    name: 'Lightly-Trodden Path',
     traversable: true,
   },
   {
     id: 'water',
     blocksLineOfSight: false,
+    name: 'Deep Water',
     traversable: false,
   },
   {
     id: 'water_shallow',
     blocksLineOfSight: false,
+    name: 'Shallows',
     traversable: true,
   },
   {
     id: 'wall',
     blocksLineOfSight: true,
+    name: 'Non-Descript Wall',
     traversable: false,
   },
 ] as const

--- a/src/ui/components/expedition-screen.css
+++ b/src/ui/components/expedition-screen.css
@@ -12,6 +12,17 @@
   overflow: hidden;
 }
 
+.main-content-footer {
+  display: flex;
+  flex-direction: row;
+}
+.expedition-panel.expedition-screen-log {
+  margin-right: 4px;
+}
+.expedition-panel.expedition-screen-tile-description {
+  margin-left: 4px;
+}
+
 .sidebar {
   display: flex;
   justify-self: flex-start;

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -18,10 +18,10 @@ import { InventoryPanel } from './inventory-panel'
 import { LogPanel } from './log-panel'
 import { MapPanel } from './map-panel'
 import { ObjectivePanel } from './objective-panel'
-import { Panel } from './panel'
 import { PlayerStatusPanel } from './player-status-panel'
 import { SpeechWindow } from './speech-window'
 import { TileDescriptionPanel } from './tile-description-panel'
+import { TooltipPanel } from './tooltip-panel'
 
 const SidebarColumns = 45
 
@@ -159,13 +159,15 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
           showSlot={true}
         />
 
-        <Panel
+        <TooltipPanel
           containerClass="expedition-panel"
           columns={SidebarColumns}
-          rows={8}
+          focusedTile={highlightedCell
+            ? world.map.getMapTile(highlightedCell.x, highlightedCell.y)
+            : undefined}
         >
           {highlightedCell && `(${highlightedCell.x}, ${highlightedCell.y})`}
-        </Panel>
+        </TooltipPanel>
       </div>
 
       <SpeechWindow

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -33,7 +33,7 @@ export interface ExpeditionScreenProps {
 export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
   const [inMenus, setInMenus] = useState(false)
   const [inSpeech, setInSpeech] = useState(false)
-  const [highlightedCell, setHighlightedCell] = useState<CellCoordinate | undefined>()
+  const [focusedCell, setFocusedCell] = useState<CellCoordinate | undefined>()
 
   const world = useWorld()
   const updateExpedition = useSetRecoilState(expeditionState)
@@ -88,11 +88,15 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
     world.player.destination = { x, y }
   }, [world.player])
 
-  const handleMapHighlight = useCallback((x: number, y: number) => {
-    setHighlightedCell((previous) => {
-      return x === previous?.x && y === previous?.y
+  const handleCellFocus = useCallback((cell) => {
+    setFocusedCell((previous) => {
+      if (cell === undefined) {
+        return cell
+      }
+
+      return cell.x === previous?.x && cell.y === previous?.y
         ? previous
-        : { x, y }
+        : cell
     })
   }, [])
 
@@ -117,9 +121,9 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
         <MapPanel
           active={!isPaused}
           containerClass="expedition-panel"
-          focusedCell={highlightedCell}
+          focusedCell={focusedCell}
+          onCellFocus={handleCellFocus}
           onMapClick={handleMapClick}
-          onMapHover={handleMapHighlight}
           onKeyDown={mapKeyHandler}
         />
 
@@ -162,12 +166,10 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
         <TooltipPanel
           containerClass="expedition-panel"
           columns={SidebarColumns}
-          focusedTile={highlightedCell
-            ? world.map.getMapTile(highlightedCell.x, highlightedCell.y)
+          focusedTile={focusedCell
+            ? world.map.getMapTile(focusedCell.x, focusedCell.y)
             : undefined}
-        >
-          {highlightedCell && `(${highlightedCell.x}, ${highlightedCell.y})`}
-        </TooltipPanel>
+        />
       </div>
 
       <SpeechWindow

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -20,8 +20,9 @@ import { ObjectivePanel } from './objective-panel'
 import { Panel } from './panel'
 import { PlayerStatusPanel } from './player-status-panel'
 import { SpeechWindow } from './speech-window'
+import { TileDescriptionPanel } from './tile-description-panel'
 
-const SidebarColumns = 35
+const SidebarColumns = 45
 
 export interface ExpeditionScreenProps {
   /** function that allows inter-screen navigation */
@@ -110,10 +111,18 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
           onKeyDown={mapKeyHandler}
         />
 
-        <LogPanel
-          containerClass="expedition-panel"
-          world={world}
-        />
+        <div className='main-content-footer'>
+          <LogPanel
+            containerClass="expedition-panel expedition-screen-log"
+            style={{ flex: 1 }}
+            world={world}
+          />
+
+          <TileDescriptionPanel
+            containerClass="expedition-panel expedition-screen-tile-description"
+            style={{ flex: 1 }}
+          />
+        </div>
       </div>
 
       <div className="sidebar">

--- a/src/ui/components/expedition-screen.tsx
+++ b/src/ui/components/expedition-screen.tsx
@@ -3,6 +3,7 @@ import './expedition-screen.css'
 import { AttackAction } from 'engine/actions/attack'
 import { DoNothing } from 'engine/actions/do-nothing'
 import { MoveByAction } from 'engine/actions/move-by'
+import { CellCoordinate } from 'engine/map/map'
 import { Action } from 'engine/types'
 import { useCallback, useEffect, useState } from 'react'
 import { useSetRecoilState } from 'recoil'
@@ -32,6 +33,7 @@ export interface ExpeditionScreenProps {
 export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
   const [inMenus, setInMenus] = useState(false)
   const [inSpeech, setInSpeech] = useState(false)
+  const [highlightedCell, setHighlightedCell] = useState<CellCoordinate | undefined>()
 
   const world = useWorld()
   const updateExpedition = useSetRecoilState(expeditionState)
@@ -86,6 +88,14 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
     world.player.destination = { x, y }
   }, [world.player])
 
+  const handleMapHighlight = useCallback((x: number, y: number) => {
+    setHighlightedCell((previous) => {
+      return x === previous?.x && y === previous?.y
+        ? previous
+        : { x, y }
+    })
+  }, [])
+
   const keyMap = getKeyMap()
   const mapKeyHandler = useKeyHandler({
     [keyMap.MoveDown]: executePlayerMove(0, 1),
@@ -107,7 +117,9 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
         <MapPanel
           active={!isPaused}
           containerClass="expedition-panel"
+          focusedCell={highlightedCell}
           onMapClick={handleMapClick}
+          onMapHover={handleMapHighlight}
           onKeyDown={mapKeyHandler}
         />
 
@@ -152,7 +164,7 @@ export const ExpeditionScreen = ({ navigateTo }: ExpeditionScreenProps) => {
           columns={SidebarColumns}
           rows={8}
         >
-          Lorem ipsum dolor sit amet.
+          {highlightedCell && `(${highlightedCell.x}, ${highlightedCell.y})`}
         </Panel>
       </div>
 

--- a/src/ui/components/map-panel.tsx
+++ b/src/ui/components/map-panel.tsx
@@ -30,11 +30,11 @@ export interface MapPanelProps extends Omit<PanelProps, 'columns' | 'rows'> {
   /** (x, y) coordinate of the cell to highlight, if any */
   focusedCell?: CellCoordinate
 
+  /** optional callback that is notified when the user moves the mouse over a cell on the map */
+  onCellFocus?: (cell: CellCoordinate | undefined) => void
+
   /** optional callback that is notified whenever the user clicks on the map */
   onMapClick?: (mapX: number, mapY: number) => void
-
-  /** optional callback that is notified when the user moves the mouse over a cell on the map */
-  onMapHover?: (mapX: number, mapY: number) => void
 
   /** callback notified whenever the size of the viewport changes, with new dimensions in map cell coordinates */
   onViewportSizeChanged?: (width: number, height: number) => void
@@ -80,8 +80,8 @@ const calculateViewportCenter = (
 
 export const MapPanel = ({
   focusedCell,
+  onCellFocus = noop,
   onMapClick = noop,
-  onMapHover = noop,
   onViewportSizeChanged = noop,
   ...panelProps
 }: MapPanelProps) => {
@@ -226,9 +226,12 @@ export const MapPanel = ({
   }, [convertMouseCoordinatesToCell, onMapClick])
 
   const handleMouseMove = useCallback((event: React.MouseEvent) => {
-    const { x, y } = convertMouseCoordinatesToCell(event.clientX, event.clientY)
-    onMapHover(x, y)
-  }, [convertMouseCoordinatesToCell, onMapHover])
+    onCellFocus(convertMouseCoordinatesToCell(event.clientX, event.clientY))
+  }, [convertMouseCoordinatesToCell, onCellFocus])
+
+  const handleMouseOut = useCallback(() => {
+    onCellFocus(undefined)
+  }, [onCellFocus])
 
   return (<>
     <Panel {...panelProps}>
@@ -236,6 +239,7 @@ export const MapPanel = ({
         className="map-canvas"
         onClick={handleClick}
         onMouseMove={handleMouseMove}
+        onMouseOut={handleMouseOut}
         style={{ flex: 1, height: '100%' }}
         ref={pixiRefCallback}
       />

--- a/src/ui/components/map-scene-graph.ts
+++ b/src/ui/components/map-scene-graph.ts
@@ -1,5 +1,5 @@
 import { Creature } from 'engine/creature'
-import { MapCell } from 'engine/map/map'
+import { CellCoordinate, MapCell } from 'engine/map/map'
 import { MapSymbol } from 'engine/map/map-symbol'
 import { getCreatureSymbol, getItemSymbol, getTerrainSymbol, withDefaultBackground } from 'engine/map/map-symbolizer'
 import { isTileVisibleTo } from 'engine/scripts/tile-visibility-sensor'
@@ -143,6 +143,7 @@ export class MapSceneGraph {
   private _mapCellsContainer: PIXI.Container
   private _creaturesContainer: PIXI.Container
 
+  private _cellHighlight: PIXI.Graphics | undefined
   private _creatureTiles: { [k in string]: CreatureTile } = {}
   private _mapCellTiles: MapCellTile[][] = []
   private _allTiles: MapCellTile[] = []
@@ -167,6 +168,33 @@ export class MapSceneGraph {
     background.drawRect(0, 0, _cellWidth, _cellHeight)
 
     this._backgroundTexture = app.renderer.generateTexture(background)
+  }
+
+  /**
+   * Sets or clears the currently 'focused' cell, which will be shown with a border
+   * or other highlight effect.
+   */
+  public setCellFocus (coordinate: CellCoordinate | undefined) {
+    if (coordinate === undefined) {
+      if (this._cellHighlight !== undefined) {
+        this._root.removeChild(this._cellHighlight)
+        this._cellHighlight = undefined
+      }
+    } else {
+      if (this._cellHighlight === undefined) {
+        this._cellHighlight = new PIXI.Graphics()
+        this._cellHighlight.lineStyle(1, 0xff0000, 0.66)
+        this._cellHighlight.beginFill(0xff0000, 0.2)
+        this._cellHighlight.drawRect(0, 0, this._cellWidth, this._cellHeight)
+
+        this._root.addChild(this._cellHighlight)
+      }
+
+      this._cellHighlight.position.set(
+        coordinate.x * this._cellWidth,
+        coordinate.y * this._cellHeight
+      )
+    }
   }
 
   public setOffset (cellX: number, cellY: number) {

--- a/src/ui/components/tile-description-panel.tsx
+++ b/src/ui/components/tile-description-panel.tsx
@@ -1,0 +1,31 @@
+import './log-panel.css'
+
+import { useWorld } from 'ui/hooks/use-world'
+import { WithExtraClasses } from 'ui/to-class-name'
+
+import { Panel, PanelProps } from './panel'
+
+export type TileDescriptionPanelProps = WithExtraClasses & Omit<PanelProps, 'className'> & {
+  /** number of log rows to display */
+  rows?: number
+}
+
+export const TileDescriptionPanel = ({ rows = 8, ...rest }: TileDescriptionPanelProps) => {
+  const world = useWorld()
+
+  const player = world.player
+  const map = world.map
+  const tile = map.getMapTile(player.x, player.y)
+  const name = tile?.terrain.name
+  const description = tile?.terrain.description ?? 'You see nothing of note here.'
+
+  return (
+    <Panel {...rest}
+      classes="description-panel"
+      rows={rows}
+      title={name}
+    >
+      {description}
+    </Panel>
+  )
+}

--- a/src/ui/components/tooltip-panel.tsx
+++ b/src/ui/components/tooltip-panel.tsx
@@ -2,7 +2,9 @@ import './log-panel.css'
 
 import { MapTile } from 'engine/map/map'
 import { Player } from 'engine/player'
+import { isTileVisibleTo } from 'engine/scripts/tile-visibility-sensor'
 import { join, map } from 'lodash/fp'
+import { useWorld } from 'ui/hooks/use-world'
 import { WithExtraClasses } from 'ui/to-class-name'
 
 import { Panel, PanelProps } from './panel'
@@ -15,44 +17,56 @@ export type TooltipPanelProps = WithExtraClasses & Omit<PanelProps, 'className'>
   rows?: number
 }
 
+const getObservationString = (focusedTile: MapTile) => {
+  const observations: string[] = []
+
+  if (focusedTile.creature !== undefined) {
+    const creature = focusedTile.creature
+
+    observations.push(creature instanceof Player ? 'yourself' : `a ${creature.name}`)
+  }
+
+  if (focusedTile.items.length > 0) {
+    const items = focusedTile.items
+
+    if (items.length === 1) {
+      observations.push(` ${items[0].name}`)
+    } else {
+      observations.push('some things on the ground')
+    }
+  }
+
+  // one item per line, with an asterisk in front of it
+  return observations.length < 1
+    ? 'You see nothing here.'
+    : `You see:\n${join('\n', map((item) => {
+      return `* ${item}`
+    }, observations))}`
+}
+
 export const TooltipPanel = ({
   focusedTile,
   rows = 8,
   ...rest
 }: TooltipPanelProps) => {
-  const observations: string[] = []
+  const world = useWorld()
+  const map = world.map
+  const player = world.player
 
-  if (focusedTile !== undefined) {
-    if (focusedTile.creature !== undefined) {
-      const creature = focusedTile.creature
+  const visible = focusedTile !== undefined && isTileVisibleTo(player, focusedTile.x, focusedTile.y, map)
 
-      observations.push(creature instanceof Player ? 'yourself' : `a ${creature.name}`)
-    }
-
-    if (focusedTile.items.length > 0) {
-      const items = focusedTile.items
-
-      if (items.length === 1) {
-        observations.push(` ${items[0].name}`)
-      } else {
-        observations.push('some things on the ground')
-      }
-    }
-  }
-
-  // one item per line, with an asterisk in front
-  const observationString = observations.length < 1
-    ? 'You see nothing here.'
-    : `You see:\n${join('\n', map((item) => {
-      return `* ${item}`
-    }, observations))}`
+  const observationString = focusedTile === undefined
+    ? undefined
+    : visible
+      ? getObservationString(focusedTile)
+      : 'You can\'t see there.'
 
   return (
     <Panel {...rest}
       classes="tooltip-panel"
       rows={rows}
       style={{ whiteSpace: 'pre-line' }}
-      title={focusedTile?.terrain.name}
+      title={visible ? focusedTile?.terrain.name : undefined}
     >{focusedTile && observationString}
     </Panel>
   )

--- a/src/ui/components/tooltip-panel.tsx
+++ b/src/ui/components/tooltip-panel.tsx
@@ -1,0 +1,59 @@
+import './log-panel.css'
+
+import { MapTile } from 'engine/map/map'
+import { Player } from 'engine/player'
+import { join, map } from 'lodash/fp'
+import { WithExtraClasses } from 'ui/to-class-name'
+
+import { Panel, PanelProps } from './panel'
+
+export type TooltipPanelProps = WithExtraClasses & Omit<PanelProps, 'className'> & {
+  /** the map tile to display a tooltip for, if any */
+  focusedTile?: MapTile
+
+  /** number of log rows to display */
+  rows?: number
+}
+
+export const TooltipPanel = ({
+  focusedTile,
+  rows = 8,
+  ...rest
+}: TooltipPanelProps) => {
+  const observations: string[] = []
+
+  if (focusedTile !== undefined) {
+    if (focusedTile.creature !== undefined) {
+      const creature = focusedTile.creature
+
+      observations.push(creature instanceof Player ? 'yourself' : `a ${creature.name}`)
+    }
+
+    if (focusedTile.items.length > 0) {
+      const items = focusedTile.items
+
+      if (items.length === 1) {
+        observations.push(` ${items[0].name}`)
+      } else {
+        observations.push('some things on the ground')
+      }
+    }
+  }
+
+  // one item per line, with an asterisk in front
+  const observationString = observations.length < 1
+    ? 'You see nothing here.'
+    : `You see:\n${join('\n', map((item) => {
+      return `* ${item}`
+    }, observations))}`
+
+  return (
+    <Panel {...rest}
+      classes="tooltip-panel"
+      rows={rows}
+      style={{ whiteSpace: 'pre-line' }}
+      title={focusedTile?.terrain.name}
+    >{focusedTile && observationString}
+    </Panel>
+  )
+}


### PR DESCRIPTION
- Updated UI layouyt to incorporate the tile description, and added basic names/decriptions to terrain types.
- Add highlight effect to cells that are moused over.
- Implement tooltip panel
- Hide cell tooltip for non-visible areas, and hide tooltip if mouse isn't over map.
- Update cell tooltip correctly if the viewport scrolls due to keyboard activity.
